### PR TITLE
RS-69: Cover redesign-added backend logic with Spock specs

### DIFF
--- a/src/test/groovy/com/jamex/refereestaffer/service/MatchServiceSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/service/MatchServiceSpec.groovy
@@ -163,4 +163,143 @@ class MatchServiceSpec extends Specification {
         1             | "city1"      | 2         | true    | true       | false
         3             | "city1"      | 2         | true    | false      | true
     }
+
+    def "should throw MatchNotFoundException when computing breakdown for missing match"() {
+        given:
+        def matchId = 44l
+
+        when:
+        matchService.computeDifficultyBreakdown(matchId)
+
+        then:
+        1 * matchRepository.findById(matchId) >> Optional.empty()
+        def exception = thrown(MatchNotFoundException)
+        exception.message == String.format(MatchNotFoundException.NOT_FOUND, matchId)
+    }
+
+    def "should compute difficulty breakdown with parts summing to total"() {
+        given:
+        def matchId = 7l
+        def homeTeam = [points: 10, place: 2, city: "city1"] as Team
+        def awayTeam = [points: 30, place: awayTeamPlace, city: awayTeamCity] as Team
+        def match = Match.builder().id(matchId).home(homeTeam).away(awayTeam).build()
+        def matchHardnessLvlMultiplier = 2.5d
+        def matchHardnessIncrementer = 100.0d
+        def matchHardnessDerbyIncrementer = 15.0d
+        def matchHardnessTopIncrementer = 11.0d
+        def matchHardnessBottomIncrementer = 7.0d
+
+        when:
+        def result = matchService.computeDifficultyBreakdown(matchId)
+
+        then:
+        1 * matchRepository.findById(matchId) >> Optional.of(match)
+        1 * matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull() >> []
+        1 * configurationRepository.findAllAsMap() >> [
+                (ConfigName.DIFFICULTY_LEVEL_MULTIPLIER)                : matchHardnessLvlMultiplier,
+                (ConfigName.DIFFICULTY_LEVEL_INCREMENTER)               : matchHardnessIncrementer,
+                (ConfigName.NUMBER_OF_EDGE_TEAMS)                       : edgeTeams as Double,
+                (ConfigName.DIFFICULTY_LEVEL_SAME_CITY_INCREMENTER)     : matchHardnessDerbyIncrementer,
+                (ConfigName.DIFFICULTY_LEVEL_MATCH_ON_TOP_INCREMENTER)  : matchHardnessTopIncrementer,
+                (ConfigName.DIFFICULTY_LEVEL_MATCH_ON_BOTTOM_INCREMENTER): matchHardnessBottomIncrementer
+        ]
+        1 * teamRepository.count() >> 3
+
+        result.matchId() == matchId
+        result.parts().base() == (matchHardnessIncrementer - 20) * matchHardnessLvlMultiplier
+        result.parts().sameCity() == (isDerby ? matchHardnessDerbyIncrementer : 0.0d)
+        result.parts().top() == (isTopMatch ? matchHardnessTopIncrementer : 0.0d)
+        result.parts().bottom() == (isBottomMatch ? matchHardnessBottomIncrementer : 0.0d)
+
+        and: "the parts always add up to the total"
+        result.total() == result.parts().base() + result.parts().sameCity() + result.parts().top() + result.parts().bottom()
+
+        and: "top and bottom are mutually exclusive"
+        !(result.parts().top() > 0 && result.parts().bottom() > 0)
+
+        and: "flags mirror the parts"
+        result.flags().sameCity() == isDerby
+        result.flags().isTop() == isTopMatch
+        result.flags().isBot() == isBottomMatch
+        result.flags().pointsDiff() == 20
+
+        where:
+        awayTeamPlace | awayTeamCity | edgeTeams | isDerby | isTopMatch | isBottomMatch
+        1             | "city2"      | 0         | false   | false      | false
+        1             | "city2"      | 2         | false   | true       | false
+        3             | "city2"      | 2         | false   | false      | true
+        1             | "city1"      | 2         | true    | true       | false
+        3             | "city1"      | 2         | true    | false      | true
+    }
+
+    def "should not include top or bottom parts in breakdown when a team is unranked"() {
+        given:
+        def matchId = 8l
+        def homeTeam = [points: homePoints, place: homePlace, city: "city1"] as Team
+        def awayTeam = [points: awayPoints, place: awayPlace, city: "city2"] as Team
+        def match = Match.builder().id(matchId).home(homeTeam).away(awayTeam).build()
+        def matchHardnessLvlMultiplier = 1.0d
+        def matchHardnessIncrementer = 100.0d
+
+        when:
+        def result = matchService.computeDifficultyBreakdown(matchId)
+
+        then:
+        1 * matchRepository.findById(matchId) >> Optional.of(match)
+        1 * matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull() >> []
+        // Deliberately no edge/top/bottom keys in the map — the unranked guard must return
+        // before those values are ever read (a lookup would NPE and fail the test).
+        1 * configurationRepository.findAllAsMap() >> [
+                (ConfigName.DIFFICULTY_LEVEL_MULTIPLIER) : matchHardnessLvlMultiplier,
+                (ConfigName.DIFFICULTY_LEVEL_INCREMENTER): matchHardnessIncrementer
+        ]
+        1 * teamRepository.count() >> 3
+
+        result.parts().top() == 0.0d
+        result.parts().bottom() == 0.0d
+        result.total() == (matchHardnessIncrementer - Math.abs(awayPoints - homePoints)) * matchHardnessLvlMultiplier
+        !result.flags().isTop()
+        !result.flags().isBot()
+
+        where:
+        homePoints | homePlace | awayPoints | awayPlace
+        0          | 0         | 0          | 0
+        0          | 0         | 30         | 1
+        30         | 1         | 0          | 0
+    }
+
+    def "should refresh standings from finished matches before computing breakdown"() {
+        given:
+        def matchId = 5l
+        def team1 = [city: "city1"] as Team
+        def team2 = [city: "city2"] as Team
+        def finishedMatches = [[homeScore: 2, awayScore: 0, home: team1, away: team2] as Match]
+        def match = Match.builder().id(matchId).home(team1).away(team2).build()
+        def matchHardnessLvlMultiplier = 2.0d
+        def matchHardnessIncrementer = 100.0d
+
+        when:
+        def result = matchService.computeDifficultyBreakdown(matchId)
+
+        then:
+        1 * matchRepository.findById(matchId) >> Optional.of(match)
+        1 * matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull() >> finishedMatches
+        1 * configurationRepository.findAllAsMap() >> [
+                (ConfigName.DIFFICULTY_LEVEL_MULTIPLIER) : matchHardnessLvlMultiplier,
+                (ConfigName.DIFFICULTY_LEVEL_INCREMENTER): matchHardnessIncrementer,
+                (ConfigName.NUMBER_OF_EDGE_TEAMS)        : 1.0d
+        ]
+        1 * teamRepository.count() >> 2
+
+        and: "points and places were computed inside the call from the finished matches"
+        team1.points == MatchService.POINTS_FOR_WIN_MATCH
+        team2.points == (short) 0
+        team1.place == (short) 1
+        team2.place == (short) 2
+
+        and: "the breakdown is based on the refreshed standings"
+        result.flags().pointsDiff() == MatchService.POINTS_FOR_WIN_MATCH
+        result.parts().base() == (matchHardnessIncrementer - MatchService.POINTS_FOR_WIN_MATCH) * matchHardnessLvlMultiplier
+        result.total() == result.parts().base()
+    }
 }

--- a/src/test/groovy/com/jamex/refereestaffer/service/RefereeServiceSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/service/RefereeServiceSpec.groovy
@@ -1,5 +1,7 @@
 package com.jamex.refereestaffer.service
 
+import com.jamex.refereestaffer.model.entity.Config
+import com.jamex.refereestaffer.model.entity.ConfigName
 import com.jamex.refereestaffer.model.entity.Grade
 import com.jamex.refereestaffer.model.entity.Match
 import com.jamex.refereestaffer.model.entity.Referee
@@ -107,6 +109,101 @@ class RefereeServiceSpec extends Specification {
         and: "referees without matches in the result get the defaults"
         referees.get(1).averageGrade == RefereeService.DEFAULT_GRADE
         referees.get(1).numberOfMatchesInRound == (short) 0
+    }
+
+    def "should count home and away wins skipping draws and unfinished matches"() {
+        given:
+        def referee = Referee.builder()
+                .firstName("John")
+                .lastName("Smith")
+                .build()
+        def team1 = Team.builder().name("team1").build()
+        def team2 = Team.builder().name("team2").build()
+        def matches = [
+                // two home wins, one away win
+                Match.builder().home(team1).away(team2).homeScore((short) 2).awayScore((short) 0).referee(referee).build(),
+                Match.builder().home(team2).away(team1).homeScore((short) 3).awayScore((short) 1).referee(referee).build(),
+                Match.builder().home(team1).away(team2).homeScore((short) 0).awayScore((short) 1).referee(referee).build(),
+                // draw — counts for neither side
+                Match.builder().home(team2).away(team1).homeScore((short) 1).awayScore((short) 1).referee(referee).build(),
+                // unfinished matches — count for neither side
+                Match.builder().home(team1).away(team2).referee(referee).build(),
+                Match.builder().home(team2).away(team1).homeScore((short) 2).referee(referee).build()
+        ]
+
+        when:
+        refereeService.calculateStats([referee])
+
+        then:
+        1 * matchRepository.findAllByRefereeIn([referee]) >> matches
+        referee.homeWins == (short) 2
+        referee.awayWins == (short) 1
+    }
+
+    def "should set zero win counters for referee without matches"() {
+        given:
+        def referee = Referee.builder()
+                .firstName("John")
+                .lastName("Smith")
+                .build()
+
+        when:
+        refereeService.calculateStats([referee])
+
+        then:
+        1 * matchRepository.findAllByRefereeIn([referee]) >> []
+        referee.homeWins == (short) 0
+        referee.awayWins == (short) 0
+    }
+
+    def "should enrich referees with potential computed from average grade and experience"() {
+        given:
+        def avgMultiplier = 6.0d
+        def expMultiplier = 0.5d
+        def referee = Referee.builder()
+                .firstName("John")
+                .lastName("Smith")
+                .experience(10)
+                .build()
+        def team1 = Team.builder().name("team1").build()
+        def team2 = Team.builder().name("team2").build()
+        def grade1 = 8.0
+        def grade2 = 9.0
+        def matches = createMatches(referee, team1, team2, team2, grade1, grade2)
+
+        when:
+        refereeService.enrichWithStats([referee])
+
+        then:
+        1 * matchRepository.findAllByRefereeIn([referee]) >> matches
+        1 * configurationRepository.findByName(ConfigName.AVERAGE_GRADE_MULTIPLIER) >> new Config(ConfigName.AVERAGE_GRADE_MULTIPLIER, avgMultiplier)
+        1 * configurationRepository.findByName(ConfigName.EXPERIENCE_MULTIPLIER) >> new Config(ConfigName.EXPERIENCE_MULTIPLIER, expMultiplier)
+
+        def expectedAverage = (grade1 + grade2) / 2
+        referee.averageGrade == expectedAverage
+        referee.potential == avgMultiplier * expectedAverage + expMultiplier * referee.experience
+    }
+
+    def "should compute potential from default grade when referee has no grades yet"() {
+        given:
+        def avgMultiplier = 6.0d
+        def expMultiplier = 0.5d
+        def referee = Referee.builder()
+                .firstName("John")
+                .lastName("Smith")
+                .experience(4)
+                .build()
+
+        when:
+        refereeService.enrichWithStats([referee])
+
+        then:
+        1 * matchRepository.findAllByRefereeIn([referee]) >> []
+        1 * configurationRepository.findByName(ConfigName.AVERAGE_GRADE_MULTIPLIER) >> new Config(ConfigName.AVERAGE_GRADE_MULTIPLIER, avgMultiplier)
+        1 * configurationRepository.findByName(ConfigName.EXPERIENCE_MULTIPLIER) >> new Config(ConfigName.EXPERIENCE_MULTIPLIER, expMultiplier)
+
+        referee.averageGrade == RefereeService.DEFAULT_GRADE
+        referee.potential == avgMultiplier * RefereeService.DEFAULT_GRADE + expMultiplier * referee.experience
     }
 
     static List<Referee> createReferees() {


### PR DESCRIPTION
## Ticket

[RS-69 — Testy logiki backendu dodanej przy redesignie](https://referee-staffer.youtrack.cloud/issue/RS-69)

The `design-refresh` branch added domain logic to the backend without any spec coverage — the biggest test gap on the backend, since this logic runs on every visit to the Staffer / match-detail / referee screens. Three areas needed tests: `MatchService.computeDifficultyBreakdown` (per-component hardness breakdown for the Staffer drawer and Match detail panels), `RefereeService.enrichWithStats` (the `P = α·avg + β·experience` potential formula with its `DEFAULT_GRADE` fallback), and the `homeWins`/`awayWins` counters in `RefereeService.calculateStats`.

## Plan

1. Extend the existing `MatchServiceSpec` with features for `computeDifficultyBreakdown`:
   - `MatchNotFoundException` for a missing match id,
   - a data-driven full-breakdown feature asserting that the parts sum to `total`, the flags mirror the parts, and `top`/`bottom` are mutually exclusive,
   - the unranked-team guard (`place == 0`) — stubbed config map deliberately omits the edge keys so a broken guard would NPE,
   - a feature proving standings (points and places) are recomputed from finished matches *inside* the call before scoring.
2. Extend the existing `RefereeServiceSpec`:
   - `enrichWithStats` computes potential from the average grade and experience using the two config multipliers,
   - `enrichWithStats` falls back to `DEFAULT_GRADE` for a referee with no graded matches,
   - `homeWins`/`awayWins`: draws and unfinished matches (including a single-`null` score) count for neither side; zero counters for a referee with no matches.
3. No production code changes; follow the existing spec conventions (Spock `Mock()`s, interaction stubbing in `then:` blocks, `where:` tables).
4. Verify with `mvn -DskipFrontend=true test`.

## Changes

- `MatchServiceSpec.groovy` — 4 new features (10 test executions) covering `computeDifficultyBreakdown`. The full-breakdown feature reuses the same `where:` table shape as the existing `getMatchesToAssignInQueue` feature so the two entry points are exercised against the same scenarios. The standings-refresh feature feeds a finished match through the mocked repository and asserts both the mutated `Team` points/places and the resulting `pointsDiff`/`base` part, proving the breakdown is computed against fresh standings rather than stale `@Transient` values.
- `RefereeServiceSpec.groovy` — 4 new features covering the win counters and `enrichWithStats`. Config multipliers are stubbed via `findByName` (matching how `enrichWithStats` reads them, as opposed to the `findAllAsMap` path used by match scoring).

Design decisions: asserted `top`/`bottom` mutual exclusivity explicitly (documented invariant of `DifficultyBreakdownDto`), and kept the NPE-trap technique from the existing unranked-guard spec for the breakdown variant so both entry points guard consistently.

## Testing

- `mvn -DskipFrontend=true test` — 130 tests, 0 failures, `BUILD SUCCESS` (JDK 25, Spock). New totals: `MatchServiceSpec` 27 executions, `RefereeServiceSpec` 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzqQA4DupN2cfedZKcDnNj

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzqQA4DupN2cfedZKcDnNj)_