### PR TITLE
RS-81: Add component specs for the redesigned UI layer

### DIFF
--- a/src/main/webapp/src/app/component/common/confirm-dialog/confirm-dialog.component.spec.ts
+++ b/src/main/webapp/src/app/component/common/confirm-dialog/confirm-dialog.component.spec.ts
@@ -1,0 +1,97 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ConfirmDialogComponent} from './confirm-dialog.component';
+import {ModalData} from '../../../model/modalData';
+
+describe('ConfirmDialogComponent', () => {
+  let fixture: ComponentFixture<ConfirmDialogComponent>;
+  let component: ConfirmDialogComponent;
+  let confirmedCount: number;
+  let cancelledCount: number;
+
+  const data: ModalData = {
+    header: 'Delete referee?',
+    message: 'This cannot be undone.'
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({imports: [ConfirmDialogComponent]}).compileComponents();
+    fixture = TestBed.createComponent(ConfirmDialogComponent);
+    component = fixture.componentInstance;
+    component.data = data;
+    confirmedCount = 0;
+    cancelledCount = 0;
+    component.confirmed.subscribe(() => confirmedCount++);
+    component.cancelled.subscribe(() => cancelledCount++);
+  });
+
+  function open(override: Partial<ModalData> = {}): HTMLElement {
+    fixture.componentRef.setInput('data', {...data, ...override});
+    fixture.componentRef.setInput('open', true);
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  it('renders nothing while closed', () => {
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.modal')).toBeNull();
+  });
+
+  it('renders header and message with default button labels', () => {
+    const el = open();
+
+    expect(el.querySelector('.modal__title')?.textContent).toContain('Delete referee?');
+    expect(el.querySelector('.modal__body')?.textContent).toContain('This cannot be undone.');
+    expect(el.querySelector('.modal__foot .btn:not(.btn--primary)')?.textContent).toContain('Cancel');
+    expect(el.querySelector('.modal__foot .btn--primary')?.textContent).toContain('Confirm');
+  });
+
+  it('renders custom button labels', () => {
+    const el = open({confirmLabel: 'Discard', cancelLabel: 'Keep editing'});
+
+    expect(el.querySelector('.modal__foot .btn:not(.btn--primary)')?.textContent).toContain('Keep editing');
+    expect(el.querySelector('.modal__foot .btn--primary')?.textContent).toContain('Discard');
+  });
+
+  it('styles the primary button as danger by default but not for warn tone', () => {
+    let el = open();
+    expect(el.querySelector('.btn--primary-danger')).not.toBeNull();
+
+    fixture.componentRef.setInput('open', false);
+    fixture.detectChanges();
+    el = open({tone: 'warn'});
+    expect(el.querySelector('.btn--primary-danger')).toBeNull();
+  });
+
+  it('emits confirmed on the primary button', () => {
+    const el = open();
+    (el.querySelector('.modal__foot .btn--primary') as HTMLButtonElement).click();
+
+    expect(confirmedCount).toBe(1);
+    expect(cancelledCount).toBe(0);
+  });
+
+  it('emits cancelled on the cancel button', () => {
+    const el = open();
+    (el.querySelector('.modal__foot .btn:not(.btn--primary)') as HTMLButtonElement).click();
+
+    expect(cancelledCount).toBe(1);
+    expect(confirmedCount).toBe(0);
+  });
+
+  it('emits cancelled on backdrop click', () => {
+    const el = open();
+    (el.querySelector('.modal-backdrop') as HTMLButtonElement).click();
+
+    expect(cancelledCount).toBe(1);
+  });
+
+  it('emits cancelled on Escape only while open', () => {
+    fixture.detectChanges();
+    document.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape'}));
+    expect(cancelledCount).toBe(0);
+
+    open();
+    document.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape'}));
+    expect(cancelledCount).toBe(1);
+  });
+});

--- a/src/main/webapp/src/app/component/common/drawer/drawer.component.spec.ts
+++ b/src/main/webapp/src/app/component/common/drawer/drawer.component.spec.ts
@@ -1,0 +1,68 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {DrawerComponent} from './drawer.component';
+
+describe('DrawerComponent', () => {
+  let fixture: ComponentFixture<DrawerComponent>;
+  let component: DrawerComponent;
+  let closedCount: number;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({imports: [DrawerComponent]}).compileComponents();
+    fixture = TestBed.createComponent(DrawerComponent);
+    component = fixture.componentInstance;
+    closedCount = 0;
+    component.closed.subscribe(() => closedCount++);
+  });
+
+  function open(): void {
+    fixture.componentRef.setInput('open', true);
+    fixture.componentRef.setInput('title', 'Inspect match');
+    fixture.detectChanges();
+  }
+
+  function pressEscape(): void {
+    document.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape'}));
+  }
+
+  it('renders nothing while closed', () => {
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.drawer')).toBeNull();
+  });
+
+  it('renders the panel with title and optional subtitle when open', () => {
+    fixture.componentRef.setInput('subtitle', 'Queue 3');
+    open();
+
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('.drawer__title')?.textContent).toContain('Inspect match');
+    expect(el.querySelector('.fdrawer__sub')?.textContent).toContain('Queue 3');
+  });
+
+  it('emits closed on the X button', () => {
+    open();
+    (fixture.nativeElement.querySelector('button[aria-label="Close"]') as HTMLButtonElement).click();
+    expect(closedCount).toBe(1);
+  });
+
+  it('emits closed on backdrop click', () => {
+    open();
+    (fixture.nativeElement.querySelector('.drawer-backdrop') as HTMLButtonElement).click();
+    expect(closedCount).toBe(1);
+  });
+
+  it('emits closed on Escape only while open', () => {
+    fixture.detectChanges();
+    pressEscape();
+    expect(closedCount).toBe(0);
+
+    open();
+    pressEscape();
+    expect(closedCount).toBe(1);
+  });
+
+  it('applies the wide variant class', () => {
+    fixture.componentRef.setInput('wide', true);
+    open();
+    expect(fixture.nativeElement.querySelector('.drawer--wide')).not.toBeNull();
+  });
+});

--- a/src/main/webapp/src/app/component/common/form-drawer/form-drawer.component.spec.ts
+++ b/src/main/webapp/src/app/component/common/form-drawer/form-drawer.component.spec.ts
@@ -1,0 +1,111 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {FormDrawerComponent} from './form-drawer.component';
+
+describe('FormDrawerComponent', () => {
+  let fixture: ComponentFixture<FormDrawerComponent>;
+  let component: FormDrawerComponent;
+  let closedCount: number;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({imports: [FormDrawerComponent]}).compileComponents();
+    fixture = TestBed.createComponent(FormDrawerComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('open', true);
+    fixture.componentRef.setInput('title', 'Add referee');
+    fixture.componentRef.setInput('formId', 'referee-form');
+    closedCount = 0;
+    component.closed.subscribe(() => closedCount++);
+    fixture.detectChanges();
+  });
+
+  function el(): HTMLElement {
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  function clickCancel(): void {
+    const buttons = el().querySelectorAll<HTMLButtonElement>('.fdrawer__actions .btn');
+    buttons[0].click();
+    fixture.detectChanges();
+  }
+
+  function guard(): HTMLElement | null {
+    return el().querySelector('.modal');
+  }
+
+  it('wires the footer submit button to the projected form and gates it on validity', () => {
+    const submit = el().querySelector('button[type="submit"]') as HTMLButtonElement;
+    expect(submit.getAttribute('form')).toBe('referee-form');
+    expect(submit.disabled).toBeTrue();
+
+    fixture.componentRef.setInput('valid', true);
+    fixture.detectChanges();
+    expect(submit.disabled).toBeFalse();
+  });
+
+  it('shows the dirty indicator', () => {
+    expect(el().querySelector('.fdrawer__dirty')?.textContent).toContain('No changes');
+
+    fixture.componentRef.setInput('dirty', true);
+    fixture.detectChanges();
+    expect(el().querySelector('.fdrawer__dirty')?.textContent).toContain('Unsaved changes');
+  });
+
+  it('closes immediately while pristine', () => {
+    clickCancel();
+
+    expect(closedCount).toBe(1);
+    expect(guard()).toBeNull();
+  });
+
+  it('routes a dirty close through the discard guard instead of closing', () => {
+    fixture.componentRef.setInput('dirty', true);
+    fixture.detectChanges();
+
+    clickCancel();
+
+    expect(closedCount).toBe(0);
+    expect(guard()).not.toBeNull();
+    expect(guard()?.textContent).toContain('Discard changes?');
+  });
+
+  it('closes once the discard guard is confirmed', () => {
+    fixture.componentRef.setInput('dirty', true);
+    fixture.detectChanges();
+    clickCancel();
+
+    (guard()!.querySelector('.modal__foot .btn--primary') as HTMLButtonElement).click();
+    fixture.detectChanges();
+
+    expect(closedCount).toBe(1);
+    expect(guard()).toBeNull();
+  });
+
+  it('keeps the drawer open when the discard guard is dismissed', () => {
+    fixture.componentRef.setInput('dirty', true);
+    fixture.detectChanges();
+    clickCancel();
+
+    (guard()!.querySelector('.modal__foot .btn:not(.btn--primary)') as HTMLButtonElement).click();
+    fixture.detectChanges();
+
+    expect(closedCount).toBe(0);
+    expect(guard()).toBeNull();
+    expect(el().querySelector('.drawer')).not.toBeNull();
+  });
+
+  it('lets Escape dismiss only the guard while it is open, not the drawer behind it', () => {
+    fixture.componentRef.setInput('dirty', true);
+    fixture.detectChanges();
+    clickCancel();
+    expect(guard()).not.toBeNull();
+
+    // Both the drawer and the dialog listen on document:keydown.escape. The drawer's
+    // tryClose() must no-op while the guard is up, and the dialog's cancel closes it.
+    document.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape'}));
+    fixture.detectChanges();
+
+    expect(guard()).toBeNull();
+    expect(closedCount).toBe(0);
+    expect(el().querySelector('.drawer')).not.toBeNull();
+  });
+});

--- a/src/main/webapp/src/app/component/common/shell/shell.component.spec.ts
+++ b/src/main/webapp/src/app/component/common/shell/shell.component.spec.ts
@@ -1,0 +1,97 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {signal, WritableSignal} from '@angular/core';
+import {provideRouter} from '@angular/router';
+import {ShellComponent} from './shell.component';
+import {UiSettingsService} from '../../../service/ui-settings.service';
+
+describe('ShellComponent', () => {
+  let fixture: ComponentFixture<ShellComponent>;
+  let settings: {
+    dark: WritableSignal<boolean>;
+    adminVisible: WritableSignal<boolean>;
+    explainerVisible: WritableSignal<boolean>;
+    toggleDark: jasmine.Spy;
+    toggleAdmin: jasmine.Spy;
+    toggleExplainer: jasmine.Spy;
+  };
+
+  beforeEach(async () => {
+    settings = {
+      dark: signal(false),
+      adminVisible: signal(false),
+      explainerVisible: signal(false),
+      toggleDark: jasmine.createSpy('toggleDark'),
+      toggleAdmin: jasmine.createSpy('toggleAdmin'),
+      toggleExplainer: jasmine.createSpy('toggleExplainer')
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [ShellComponent],
+      providers: [
+        provideRouter([]),
+        {provide: UiSettingsService, useValue: settings}
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ShellComponent);
+    fixture.detectChanges();
+  });
+
+  function el(): HTMLElement {
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  function navLabels(): string[] {
+    return Array.from(el().querySelectorAll('a.nav-item'))
+      .map(a => a.textContent?.trim() ?? '');
+  }
+
+  it('renders the workspace, data and setup groups', () => {
+    expect(navLabels()).toEqual([
+      'Overview', 'Staffer',
+      'Matches', 'Referees', 'Grades',
+      'Import data', 'Configuration'
+    ]);
+  });
+
+  it('hides the admin group until it is revealed', () => {
+    expect(navLabels()).not.toContain('Teams');
+    expect(el().querySelector('.nav-group--admin')).toBeNull();
+
+    settings.adminVisible.set(true);
+    fixture.detectChanges();
+
+    expect(el().querySelector('.nav-group--admin')).not.toBeNull();
+    expect(navLabels()).toEqual(jasmine.arrayContaining(['Teams', 'Standings', 'Vacations']));
+  });
+
+  it('labels the temporary admin toggle by the current state', () => {
+    const toggle = el().querySelector('.sidenav__admin-toggle') as HTMLButtonElement;
+    expect(toggle.textContent).toContain('Show admin section');
+
+    settings.adminVisible.set(true);
+    fixture.detectChanges();
+    expect(toggle.textContent).toContain('Hide admin section');
+
+    toggle.click();
+    expect(settings.toggleAdmin).toHaveBeenCalled();
+  });
+
+  it('hosts the algorithm-explainer toggle inside the admin group', () => {
+    expect(el().querySelector('.nav-item--toggle')).toBeNull();
+
+    settings.adminVisible.set(true);
+    fixture.detectChanges();
+
+    const toggle = el().querySelector('.nav-item--toggle') as HTMLButtonElement;
+    expect(toggle.textContent).toContain('Algorithm explainer');
+    toggle.click();
+    expect(settings.toggleExplainer).toHaveBeenCalled();
+  });
+
+  it('flips the theme from the topbar button', () => {
+    (el().querySelector('.topbar__theme') as HTMLButtonElement).click();
+
+    expect(settings.toggleDark).toHaveBeenCalled();
+  });
+});

--- a/src/main/webapp/src/app/component/importer/importer.component.spec.ts
+++ b/src/main/webapp/src/app/component/importer/importer.component.spec.ts
@@ -1,0 +1,96 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {of, Subject, throwError} from 'rxjs';
+import {ImporterComponent} from './importer.component';
+import {ImporterService} from '../../service/importer.service';
+import {ImportResponse} from '../../request/importResponse';
+
+describe('ImporterComponent', () => {
+  let fixture: ComponentFixture<ImporterComponent>;
+  let component: ImporterComponent;
+  let importerService: jasmine.SpyObj<ImporterService>;
+
+  const csv = new File(['a;b;c'], 'season.csv', {type: 'text/csv'});
+  const response = {} as ImportResponse;
+
+  beforeEach(async () => {
+    importerService = jasmine.createSpyObj('ImporterService', ['postFile', 'downloadExampleFile']);
+    await TestBed.configureTestingModule({
+      imports: [ImporterComponent],
+      providers: [{provide: ImporterService, useValue: importerService}]
+    }).compileComponents();
+    fixture = TestBed.createComponent(ImporterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  function selectFile(file: File | null): void {
+    const event = {target: {files: {item: () => file}}} as unknown as Event;
+    component.handleFileInput(event);
+  }
+
+  it('stores the picked file and clears the previous run outcome', () => {
+    component.importResult.set(response);
+    component.importError.set('old error');
+
+    selectFile(csv);
+
+    expect(component.fileToUpload()).toBe(csv);
+    expect(component.importResult()).toBeNull();
+    expect(component.importError()).toBeNull();
+  });
+
+  it('does not upload until both the file and the queue count are set', () => {
+    component.upload();
+    expect(importerService.postFile).not.toHaveBeenCalled();
+
+    selectFile(csv);
+    component.upload();
+    expect(importerService.postFile).not.toHaveBeenCalled();
+
+    importerService.postFile.and.returnValue(of(response));
+    component.setNumberOfQueues(30);
+    component.upload();
+    expect(importerService.postFile).toHaveBeenCalledWith(csv, 30);
+  });
+
+  it('tracks the uploading flag across a successful import', () => {
+    const upload = new Subject<ImportResponse>();
+    importerService.postFile.and.returnValue(upload);
+    selectFile(csv);
+    component.setNumberOfQueues(30);
+
+    component.upload();
+    expect(component.uploading()).toBeTrue();
+
+    upload.next(response);
+    expect(component.uploading()).toBeFalse();
+    expect(component.importResult()).toBe(response);
+    expect(component.importError()).toBeNull();
+  });
+
+  it('surfaces a friendly message when the import fails', () => {
+    importerService.postFile.and.returnValue(throwError(() => new Error('500')));
+    selectFile(csv);
+    component.setNumberOfQueues(30);
+
+    component.upload();
+
+    expect(component.uploading()).toBeFalse();
+    expect(component.importResult()).toBeNull();
+    expect(component.importError()).toContain('Import failed');
+  });
+
+  it('clears a previous error when retrying', () => {
+    importerService.postFile.and.returnValue(throwError(() => new Error('500')));
+    selectFile(csv);
+    component.setNumberOfQueues(30);
+    component.upload();
+    expect(component.importError()).not.toBeNull();
+
+    importerService.postFile.and.returnValue(of(response));
+    component.upload();
+
+    expect(component.importError()).toBeNull();
+    expect(component.importResult()).toBe(response);
+  });
+});

--- a/src/main/webapp/src/app/component/match-form/match-form.component.spec.ts
+++ b/src/main/webapp/src/app/component/match-form/match-form.component.spec.ts
@@ -1,0 +1,247 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {NgForm} from '@angular/forms';
+import {of, Subject} from 'rxjs';
+import {MatchFormComponent} from './match-form.component';
+import {MatchService} from '../../service/match.service';
+import {TeamService} from '../../service/team.service';
+import {RefereeService} from '../../service/referee.service';
+import {GradeService} from '../../service/grade.service';
+import {Match} from '../../model/match';
+import {Team} from '../../model/team';
+import {Referee} from '../../model/referee';
+import {Grade} from '../../model/grade';
+
+describe('MatchFormComponent', () => {
+  let matchService: jasmine.SpyObj<MatchService>;
+  let teamService: jasmine.SpyObj<TeamService>;
+  let refereeService: jasmine.SpyObj<RefereeService>;
+  let gradeService: jasmine.SpyObj<GradeService>;
+
+  const teams: Team[] = [
+    {id: 1, name: 'Alfa', city: 'Krakow', points: 40},
+    {id: 2, name: 'Beta', city: 'Gdansk', points: 30}
+  ];
+
+  const referees: Referee[] = [
+    {id: 100, firstName: 'Jan', lastName: 'Kowalski', email: 'jan@example.com', experience: 10}
+  ];
+
+  function makeMatch(overrides: Partial<Match> = {}): Match {
+    return {
+      id: 7,
+      queue: 3,
+      homeTeamId: 1,
+      awayTeamId: 2,
+      date: new Date('2026-03-01T12:00:00'),
+      refereeId: 100,
+      gradeId: undefined,
+      homeScore: 2,
+      awayScore: 1,
+      ...overrides
+    } as Match;
+  }
+
+  const validForm = {valid: true} as NgForm;
+  const invalidForm = {valid: false} as NgForm;
+
+  beforeEach(async () => {
+    matchService = jasmine.createSpyObj('MatchService', ['save', 'update']);
+    teamService = jasmine.createSpyObj('TeamService', ['findAll']);
+    refereeService = jasmine.createSpyObj('RefereeService', ['findAll']);
+    gradeService = jasmine.createSpyObj('GradeService', ['findById', 'save', 'update', 'delete']);
+
+    teamService.findAll.and.returnValue(of(teams));
+    refereeService.findAll.and.returnValue(of(referees));
+
+    await TestBed.configureTestingModule({
+      imports: [MatchFormComponent],
+      providers: [
+        {provide: MatchService, useValue: matchService},
+        {provide: TeamService, useValue: teamService},
+        {provide: RefereeService, useValue: refereeService},
+        {provide: GradeService, useValue: gradeService}
+      ]
+    }).compileComponents();
+  });
+
+  function createComponent(match: Match | null): ComponentFixture<MatchFormComponent> {
+    const fixture = TestBed.createComponent(MatchFormComponent);
+    fixture.componentInstance.match = match;
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  describe('initialization', () => {
+    it('loads teams and referees for the selects in add mode', () => {
+      const component = createComponent(null).componentInstance;
+
+      expect(component.teams).toEqual(teams);
+      expect(component.referees).toEqual(referees);
+      expect(component.editMode).toBeFalse();
+      expect(component.model).toEqual({} as Match);
+      expect(gradeService.findById).not.toHaveBeenCalled();
+    });
+
+    it('copies the edited match into the form model so edits do not leak into the list', () => {
+      const match = makeMatch();
+      const component = createComponent(match).componentInstance;
+
+      expect(component.editMode).toBeTrue();
+      expect(component.model).toEqual(match);
+      expect(component.model).not.toBe(match);
+
+      component.model.queue = 99;
+      expect(match.queue).toBe(3);
+    });
+
+    it('fetches the existing grade when the match references one', () => {
+      const grade: Grade = {id: 5, value: 8.1};
+      gradeService.findById.and.returnValue(of(grade));
+
+      const component = createComponent(makeMatch({gradeId: 5})).componentInstance;
+
+      expect(gradeService.findById).toHaveBeenCalledWith(5);
+      expect(component.grade).toEqual(grade);
+    });
+
+    it('shows the mode in the drawer title', () => {
+      const addFixture = createComponent(null);
+      expect((addFixture.nativeElement as HTMLElement).querySelector('.drawer__title')?.textContent)
+        .toContain('Add match');
+      addFixture.destroy();
+
+      const editFixture = createComponent(makeMatch());
+      expect((editFixture.nativeElement as HTMLElement).querySelector('.drawer__title')?.textContent)
+        .toContain('Edit match');
+    });
+  });
+
+  describe('submit in add mode', () => {
+    it('does nothing while the form is invalid', () => {
+      const component = createComponent(null).componentInstance;
+
+      component.onSubmit(invalidForm);
+
+      expect(matchService.save).not.toHaveBeenCalled();
+      expect(matchService.update).not.toHaveBeenCalled();
+    });
+
+    it('saves the match and emits it when no grade was entered', () => {
+      const component = createComponent(null).componentInstance;
+      const saved = makeMatch({id: 42});
+      matchService.save.and.returnValue(of(saved));
+      const emitted: Match[] = [];
+      component.saved.subscribe(m => emitted.push(m));
+
+      component.model = {queue: 3, homeTeamId: 1, awayTeamId: 2} as Match;
+      component.onSubmit(validForm);
+
+      expect(matchService.save).toHaveBeenCalledWith(component.model);
+      expect(gradeService.save).not.toHaveBeenCalled();
+      expect(emitted).toEqual([saved]);
+    });
+
+    it('saves an entered grade against the newly created match before emitting', () => {
+      const component = createComponent(null).componentInstance;
+      const saved = makeMatch({id: 42});
+      matchService.save.and.returnValue(of(saved));
+      const gradeSave = new Subject<Grade>();
+      gradeService.save.and.returnValue(gradeSave);
+      const emitted: Match[] = [];
+      component.saved.subscribe(m => emitted.push(m));
+
+      component.grade.value = 8.4;
+      component.onSubmit(validForm);
+
+      // The grade must be attached to the match id returned by the backend,
+      // and `saved` must not fire until the grade round-trip finishes.
+      expect(gradeService.save).toHaveBeenCalledWith(saved, component.grade);
+      expect(emitted).toEqual([]);
+
+      gradeSave.next(component.grade);
+      expect(emitted).toEqual([saved]);
+    });
+  });
+
+  describe('submit in edit mode', () => {
+    let component: MatchFormComponent;
+    let updated: Match;
+    let emitted: Match[];
+
+    beforeEach(() => {
+      updated = makeMatch({queue: 4});
+      matchService.update.and.returnValue(of(updated));
+      emitted = [];
+    });
+
+    function createInEditMode(gradeId?: number, storedGrade?: Grade): void {
+      if (storedGrade) gradeService.findById.and.returnValue(of(storedGrade));
+      component = createComponent(makeMatch({gradeId})).componentInstance;
+      component.saved.subscribe(m => emitted.push(m));
+    }
+
+    it('updates the match and emits it when the grade was never touched', () => {
+      createInEditMode();
+
+      component.onSubmit(validForm);
+
+      expect(matchService.update).toHaveBeenCalledWith(component.model);
+      expect(gradeService.save).not.toHaveBeenCalled();
+      expect(gradeService.update).not.toHaveBeenCalled();
+      expect(gradeService.delete).not.toHaveBeenCalled();
+      expect(emitted).toEqual([updated]);
+    });
+
+    it('updates an existing grade when its value was changed', () => {
+      createInEditMode(5, {id: 5, value: 7.5});
+      gradeService.update.and.returnValue(of({id: 5, value: 8.0}));
+
+      component.grade.value = 8.0;
+      component.onSubmit(validForm);
+
+      expect(gradeService.update).toHaveBeenCalledWith(component.grade);
+      expect(gradeService.save).not.toHaveBeenCalled();
+      expect(gradeService.delete).not.toHaveBeenCalled();
+      expect(emitted).toEqual([updated]);
+    });
+
+    it('creates the grade when one was entered for a match without one', () => {
+      createInEditMode();
+      gradeService.save.and.returnValue(of({id: 6, value: 8.2}));
+
+      component.grade.value = 8.2;
+      component.onSubmit(validForm);
+
+      expect(gradeService.save).toHaveBeenCalledWith(updated, component.grade);
+      expect(gradeService.update).not.toHaveBeenCalled();
+      expect(gradeService.delete).not.toHaveBeenCalled();
+      expect(emitted).toEqual([updated]);
+    });
+
+    it('deletes the grade when its value was cleared', () => {
+      createInEditMode(5, {id: 5, value: 7.5});
+      const gradeDelete = new Subject<void>();
+      gradeService.delete.and.returnValue(gradeDelete);
+
+      component.grade.value = undefined as unknown as number;
+      component.onSubmit(validForm);
+
+      expect(gradeService.delete).toHaveBeenCalledWith(component.grade);
+      expect(gradeService.update).not.toHaveBeenCalled();
+      expect(gradeService.save).not.toHaveBeenCalled();
+      // Emission waits for the delete to complete.
+      expect(emitted).toEqual([]);
+      gradeDelete.next();
+      expect(emitted).toEqual([updated]);
+    });
+
+    it('does not touch any service while the form is invalid', () => {
+      createInEditMode();
+
+      component.onSubmit(invalidForm);
+
+      expect(matchService.update).not.toHaveBeenCalled();
+      expect(emitted).toEqual([]);
+    });
+  });
+});

--- a/src/main/webapp/src/app/component/match-list/match-list.component.spec.ts
+++ b/src/main/webapp/src/app/component/match-list/match-list.component.spec.ts
@@ -1,0 +1,187 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ActivatedRoute, convertToParamMap, Router} from '@angular/router';
+import {of} from 'rxjs';
+import {MatchListComponent} from './match-list.component';
+import {MatchService} from '../../service/match.service';
+import {TeamService} from '../../service/team.service';
+import {RefereeService} from '../../service/referee.service';
+import {GradeService} from '../../service/grade.service';
+import {Match} from '../../model/match';
+import {Team} from '../../model/team';
+import {Referee} from '../../model/referee';
+import {Grade} from '../../model/grade';
+
+describe('MatchListComponent', () => {
+  let matchService: jasmine.SpyObj<MatchService>;
+  let teamService: jasmine.SpyObj<TeamService>;
+  let refereeService: jasmine.SpyObj<RefereeService>;
+  let gradeService: jasmine.SpyObj<GradeService>;
+  let router: jasmine.SpyObj<Router>;
+
+  const teams: Team[] = [
+    {id: 1, name: 'Alfa', city: 'Krakow', points: 40},
+    {id: 2, name: 'Beta', city: 'Gdansk', points: 30},
+    {id: 3, name: 'Gamma', city: 'Poznan', points: 20}
+  ];
+  const referees: Referee[] = [
+    {id: 100, firstName: 'Jan', lastName: 'Kowalski', email: 'jan@example.com', experience: 10}
+  ];
+  const grades: Grade[] = [{id: 500, value: 8.4}];
+
+  function makeMatch(id: number, overrides: Partial<Match> = {}): Match {
+    return {
+      id,
+      queue: 1,
+      homeTeamId: 1,
+      awayTeamId: 2,
+      date: new Date('2026-03-01T12:00:00'),
+      refereeId: undefined,
+      gradeId: undefined,
+      homeScore: undefined,
+      awayScore: undefined,
+      ...overrides
+    } as Match;
+  }
+
+  const matches: Match[] = [
+    makeMatch(11, {queue: 1, refereeId: 100, gradeId: 500, homeScore: 2, awayScore: 1}),
+    makeMatch(12, {queue: 2, homeTeamId: 2, awayTeamId: 3}),
+    makeMatch(13, {queue: 2, homeTeamId: 3, awayTeamId: 1})
+  ];
+
+  beforeEach(() => {
+    matchService = jasmine.createSpyObj('MatchService', ['findAll', 'findById', 'delete']);
+    teamService = jasmine.createSpyObj('TeamService', ['findByIds', 'findAll']);
+    refereeService = jasmine.createSpyObj('RefereeService', ['findByIds', 'findAll']);
+    gradeService = jasmine.createSpyObj('GradeService', ['findByIds', 'findById']);
+    router = jasmine.createSpyObj('Router', ['navigate']);
+
+    matchService.findAll.and.returnValue(of(matches));
+    teamService.findByIds.and.returnValue(of(teams));
+    refereeService.findByIds.and.returnValue(of(referees));
+    gradeService.findByIds.and.returnValue(of(grades));
+    // The match form (rendered when the drawer opens) loads these on init.
+    teamService.findAll.and.returnValue(of(teams));
+    refereeService.findAll.and.returnValue(of(referees));
+    gradeService.findById.and.returnValue(of(grades[0]));
+  });
+
+  async function create(path = 'matches', id?: number): Promise<ComponentFixture<MatchListComponent>> {
+    await TestBed.configureTestingModule({
+      imports: [MatchListComponent],
+      providers: [
+        {provide: MatchService, useValue: matchService},
+        {provide: TeamService, useValue: teamService},
+        {provide: RefereeService, useValue: refereeService},
+        {provide: GradeService, useValue: gradeService},
+        {provide: Router, useValue: router},
+        {
+          provide: ActivatedRoute,
+          useValue: {snapshot: {url: [{path}], paramMap: convertToParamMap(id ? {id: String(id)} : {})}}
+        }
+      ]
+    }).compileComponents();
+    const fixture = TestBed.createComponent(MatchListComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('joins matches with teams, referees and grades by the ids actually referenced', async () => {
+    const component = (await create()).componentInstance;
+
+    expect(teamService.findByIds).toHaveBeenCalledWith([1, 2, 3]);
+    expect(refereeService.findByIds).toHaveBeenCalledWith([100]);
+    expect(gradeService.findByIds).toHaveBeenCalledWith([500]);
+    expect(component.getTeam(1)?.name).toBe('Alfa');
+    expect(component.getReferee(100)?.lastName).toBe('Kowalski');
+    expect(component.getGrade(500)?.value).toBe(8.4);
+  });
+
+  it('skips the referee and grade lookups when nothing references them', async () => {
+    matchService.findAll.and.returnValue(of([makeMatch(21), makeMatch(22, {homeTeamId: 2, awayTeamId: 3})]));
+
+    const component = (await create()).componentInstance;
+
+    expect(refereeService.findByIds).not.toHaveBeenCalled();
+    expect(gradeService.findByIds).not.toHaveBeenCalled();
+    expect(component.matches().length).toBe(2);
+  });
+
+  it('defaults to the latest queue and lists queues descending', async () => {
+    const component = (await create()).componentInstance;
+
+    expect(component.availableQueues()).toEqual([2, 1]);
+    expect(component.selectedQueue()).toBe(2);
+  });
+
+  it('filters by selected queue and team-name search', async () => {
+    const component = (await create()).componentInstance;
+
+    expect(component.visibleMatches().map(m => m.id)).toEqual([12, 13]);
+
+    component.selectQueue(1);
+    expect(component.visibleMatches().map(m => m.id)).toEqual([11]);
+
+    component.selectQueue(2);
+    component.setSearch('gamma');
+    expect(component.visibleMatches().map(m => m.id)).toEqual([12, 13]);
+
+    component.setSearch('alfa');
+    expect(component.visibleMatches().map(m => m.id)).toEqual([13]);
+  });
+
+  it('renders the score only when both halves are present', async () => {
+    const component = (await create()).componentInstance;
+
+    expect(component.scoreOrPlaceholder(matches[0])).toBe('2 – 1');
+    expect(component.scoreOrPlaceholder(matches[1])).toBeNull();
+    expect(component.scoreOrPlaceholder(makeMatch(31, {homeScore: 1}))).toBeNull();
+  });
+
+  it('scales a 1..10 grade to the 0..100 meter', async () => {
+    const component = (await create()).componentInstance;
+
+    expect(component.gradeAsMeter(grades[0])).toBe(84);
+    expect(component.gradeAsMeter(undefined)).toBe(0);
+  });
+
+  it('deletes only after the confirm, labelling the fixture in the guard', async () => {
+    const component = (await create()).componentInstance;
+    matchService.delete.and.returnValue(of(void 0));
+
+    component.askDelete(matches[0], new Event('click'));
+    expect(component.deleteGuard().message).toContain('Alfa – Beta');
+    expect(matchService.delete).not.toHaveBeenCalled();
+
+    component.confirmDelete();
+
+    expect(matchService.delete).toHaveBeenCalledWith(11);
+    expect(component.matches().map(m => m.id)).toEqual([12, 13]);
+    expect(component.deleteTarget()).toBeNull();
+  });
+
+  describe('deep links', () => {
+    it('opens an empty drawer for /addMatch', async () => {
+      const component = (await create('addMatch')).componentInstance;
+
+      expect(component.formOpen()).toBeTrue();
+      expect(component.editingMatch()).toBeNull();
+    });
+
+    it('fetches the match and opens the edit drawer for /addMatch/:id', async () => {
+      matchService.findById.and.returnValue(of(matches[0]));
+
+      const component = (await create('addMatch', 11)).componentInstance;
+
+      expect(matchService.findById).toHaveBeenCalledWith(11);
+      expect(component.editingMatch()).toEqual(matches[0]);
+      expect(component.formOpen()).toBeTrue();
+    });
+
+    it('normalizes the URL back to the list on close only when deep-linked', async () => {
+      const deepLinked = (await create('addMatch')).componentInstance;
+      deepLinked.closeForm();
+      expect(router.navigate).toHaveBeenCalledWith(['/matches']);
+    });
+  });
+});

--- a/src/main/webapp/src/app/component/referee-form/referee-form.component.spec.ts
+++ b/src/main/webapp/src/app/component/referee-form/referee-form.component.spec.ts
@@ -1,0 +1,145 @@
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {NgForm} from '@angular/forms';
+import {of} from 'rxjs';
+import {RefereeFormComponent} from './referee-form.component';
+import {RefereeService} from '../../service/referee.service';
+import {Referee} from '../../model/referee';
+
+describe('RefereeFormComponent', () => {
+  let refereeService: jasmine.SpyObj<RefereeService>;
+
+  const existing: Referee = {
+    id: 9,
+    firstName: 'Jan',
+    lastName: 'Kowalski',
+    email: 'jan@example.com',
+    experience: 12,
+    // Enriched stats never shown in the form — they must survive an edit untouched.
+    averageGrade: 8.2,
+    potential: 88,
+    lastQueue: 24
+  };
+
+  const validForm = {valid: true} as NgForm;
+
+  beforeEach(async () => {
+    refereeService = jasmine.createSpyObj('RefereeService', ['save', 'update']);
+    await TestBed.configureTestingModule({
+      imports: [RefereeFormComponent],
+      providers: [{provide: RefereeService, useValue: refereeService}]
+    }).compileComponents();
+  });
+
+  function create(referee: Referee | null): ComponentFixture<RefereeFormComponent> {
+    const fixture = TestBed.createComponent(RefereeFormComponent);
+    fixture.componentInstance.referee = referee;
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('starts empty in add mode', () => {
+    const component = create(null).componentInstance;
+
+    expect(component.editMode).toBeFalse();
+    expect(component.subtitle).toBe('New official in the pool');
+    expect(component.model.firstName).toBe('');
+  });
+
+  it('copies only the editable fields in edit mode', () => {
+    const component = create(existing).componentInstance;
+
+    expect(component.editMode).toBeTrue();
+    expect(component.subtitle).toBe('Jan Kowalski');
+    expect(component.model).toEqual({
+      firstName: 'Jan', lastName: 'Kowalski', email: 'jan@example.com', experience: 12
+    });
+  });
+
+  it('ignores submit while the form is invalid', () => {
+    create(null).componentInstance.onSubmit({valid: false} as NgForm);
+
+    expect(refereeService.save).not.toHaveBeenCalled();
+    expect(refereeService.update).not.toHaveBeenCalled();
+  });
+
+  it('saves a new referee and emits the backend response', () => {
+    const component = create(null).componentInstance;
+    const saved = {...existing, id: 55};
+    refereeService.save.and.returnValue(of(saved));
+    const emitted: Referee[] = [];
+    component.saved.subscribe(r => emitted.push(r));
+
+    component.model = {firstName: 'Anna', lastName: 'Nowak', email: 'anna@example.com', experience: 3};
+    component.onSubmit(validForm);
+
+    expect(refereeService.save).toHaveBeenCalledWith(jasmine.objectContaining({
+      firstName: 'Anna', lastName: 'Nowak', email: 'anna@example.com', experience: 3
+    }));
+    expect(refereeService.update).not.toHaveBeenCalled();
+    expect(emitted).toEqual([saved]);
+  });
+
+  it('updates on edit with the enriched stats riding along in the payload', () => {
+    const component = create(existing).componentInstance;
+    refereeService.update.and.returnValue(of(existing));
+
+    component.model.experience = 13;
+    component.onSubmit(validForm);
+
+    expect(refereeService.update).toHaveBeenCalledWith(jasmine.objectContaining({
+      id: 9, experience: 13, averageGrade: 8.2, potential: 88, lastQueue: 24
+    }));
+    expect(refereeService.save).not.toHaveBeenCalled();
+  });
+
+  it('shows validation errors only after a field is touched or dirtied', fakeAsync(() => {
+    const fixture = create(null);
+    tick();
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement;
+
+    // All fields are empty and invalid, but pristine — no errors yet.
+    expect(el.querySelectorAll('.err').length).toBe(0);
+
+    // Dirty the first-name field, then empty it again.
+    const firstName = el.querySelector('#firstName') as HTMLInputElement;
+    firstName.value = 'J';
+    firstName.dispatchEvent(new Event('input'));
+    firstName.value = '';
+    firstName.dispatchEvent(new Event('input'));
+    tick();
+    fixture.detectChanges();
+
+    expect(el.querySelectorAll('.err').length).toBe(1);
+    expect(el.querySelector('.err')?.textContent).toContain('First name is required');
+  }));
+
+  it('rejects an email without a TLD via the pattern and keeps submit disabled until all fields are valid', fakeAsync(() => {
+    const fixture = create(null);
+    tick();
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement;
+    const submit = el.querySelector('button[type="submit"]') as HTMLButtonElement;
+    expect(submit.disabled).toBeTrue();
+
+    function type(selector: string, value: string): void {
+      const input = el.querySelector(selector) as HTMLInputElement;
+      input.value = value;
+      input.dispatchEvent(new Event('input'));
+    }
+
+    type('#firstName', 'Jan');
+    type('#lastName', 'Kowalski');
+    type('#experience', '5');
+    // Angular's email validator would accept this; the stricter pattern must not.
+    type('#email', 'jan@localhost');
+    tick();
+    fixture.detectChanges();
+    expect(submit.disabled).toBeTrue();
+
+    type('#email', 'jan@example.com');
+    tick();
+    fixture.detectChanges();
+    expect(submit.disabled).toBeFalse();
+  }));
+});

--- a/src/main/webapp/src/app/component/referee-list/referee-list.component.spec.ts
+++ b/src/main/webapp/src/app/component/referee-list/referee-list.component.spec.ts
@@ -1,0 +1,153 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ActivatedRoute, convertToParamMap, Router} from '@angular/router';
+import {of} from 'rxjs';
+import {RefereeListComponent} from './referee-list.component';
+import {RefereeService} from '../../service/referee.service';
+import {Referee} from '../../model/referee';
+
+describe('RefereeListComponent', () => {
+  let refereeService: jasmine.SpyObj<RefereeService>;
+  let router: jasmine.SpyObj<Router>;
+
+  const referees: Referee[] = [
+    {id: 1, firstName: 'Jan', lastName: 'Kowalski', email: 'jan@example.com', experience: 10, potential: 70},
+    {id: 2, firstName: 'Anna', lastName: 'Nowak', email: 'anna@example.com', experience: 20, potential: 90},
+    // Un-enriched: no potential, ranks by experience.
+    {id: 3, firstName: 'Piotr', lastName: 'Wisniewski', email: 'piotr@example.com', experience: 80}
+  ];
+
+  beforeEach(() => {
+    refereeService = jasmine.createSpyObj('RefereeService', ['findAll', 'findById', 'delete']);
+    refereeService.findAll.and.returnValue(of(referees));
+    router = jasmine.createSpyObj('Router', ['navigate']);
+  });
+
+  async function create(path = 'referees', id?: number): Promise<ComponentFixture<RefereeListComponent>> {
+    await TestBed.configureTestingModule({
+      imports: [RefereeListComponent],
+      providers: [
+        {provide: RefereeService, useValue: refereeService},
+        {provide: Router, useValue: router},
+        {
+          provide: ActivatedRoute,
+          useValue: {snapshot: {url: [{path}], paramMap: convertToParamMap(id ? {id: String(id)} : {})}}
+        }
+      ]
+    }).compileComponents();
+    const fixture = TestBed.createComponent(RefereeListComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('loads the pool and ranks by potential with experience fallback', async () => {
+    const fixture = await create();
+
+    // 90 (Nowak), 80-by-experience (Wisniewski), 70 (Kowalski).
+    expect(fixture.componentInstance.visibleReferees().map(r => r.id)).toEqual([2, 3, 1]);
+    expect((fixture.nativeElement as HTMLElement).querySelectorAll('tbody tr').length).toBe(3);
+  });
+
+  it('filters by name or email', async () => {
+    const component = (await create()).componentInstance;
+
+    component.setSearch('nowak');
+    expect(component.visibleReferees().map(r => r.id)).toEqual([2]);
+
+    component.setSearch('piotr@');
+    expect(component.visibleReferees().map(r => r.id)).toEqual([3]);
+
+    component.setSearch('nikt taki');
+    expect(component.visibleReferees()).toEqual([]);
+  });
+
+  it('scales the potential meter to the pool maximum', async () => {
+    const component = (await create()).componentInstance;
+
+    expect(component.maxPotential()).toBe(90);
+    expect(component.potentialPct(referees[1])).toBe(100);
+    expect(component.potentialPct(referees[0])).toBe(78); // 70/90
+    expect(component.potentialPct(referees[2])).toBe(0);  // no potential
+  });
+
+  it('navigates to the profile on row click', async () => {
+    const component = (await create()).componentInstance;
+
+    component.openProfile(referees[0]);
+
+    expect(router.navigate).toHaveBeenCalledWith(['/referees', 1]);
+  });
+
+  describe('delete flow', () => {
+    it('asks for confirmation naming the referee, then deletes on confirm', async () => {
+      const fixture = await create();
+      const component = fixture.componentInstance;
+      refereeService.delete.and.returnValue(of(void 0));
+
+      component.askDelete(referees[1], new Event('click'));
+      fixture.detectChanges();
+
+      expect(component.deleteGuard().message).toContain('Anna Nowak');
+      expect((fixture.nativeElement as HTMLElement).querySelector('.modal')).not.toBeNull();
+
+      component.confirmDelete();
+
+      expect(refereeService.delete).toHaveBeenCalledWith(2);
+      expect(component.referees().map(r => r.id)).toEqual([1, 3]);
+      expect(component.deleteTarget()).toBeNull();
+    });
+
+    it('does nothing when confirming without a target', async () => {
+      (await create()).componentInstance.confirmDelete();
+
+      expect(refereeService.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deep links', () => {
+    it('opens an empty drawer for /addReferee', async () => {
+      const component = (await create('addReferee')).componentInstance;
+
+      expect(component.formOpen()).toBeTrue();
+      expect(component.editingReferee()).toBeNull();
+    });
+
+    it('fetches the referee and opens the edit drawer for /addReferee/:id', async () => {
+      refereeService.findById.and.returnValue(of(referees[0]));
+
+      const component = (await create('addReferee', 1)).componentInstance;
+
+      expect(refereeService.findById).toHaveBeenCalledWith(1);
+      expect(component.formOpen()).toBeTrue();
+      expect(component.editingReferee()).toEqual(referees[0]);
+    });
+
+    it('normalizes the URL back to the list when the deep-linked drawer closes', async () => {
+      const component = (await create('addReferee')).componentInstance;
+
+      component.closeForm();
+
+      expect(component.formOpen()).toBeFalse();
+      expect(router.navigate).toHaveBeenCalledWith(['/referees']);
+    });
+
+    it('does not touch the URL when closing a drawer opened from the list', async () => {
+      const component = (await create()).componentInstance;
+      component.addReferee();
+
+      component.closeForm();
+
+      expect(router.navigate).not.toHaveBeenCalled();
+    });
+  });
+
+  it('re-fetches the enriched list after a save and closes the drawer', async () => {
+    const component = (await create()).componentInstance;
+    component.addReferee();
+    refereeService.findAll.calls.reset();
+
+    component.onSaved();
+
+    expect(refereeService.findAll).toHaveBeenCalledTimes(1);
+    expect(component.formOpen()).toBeFalse();
+  });
+});

--- a/src/main/webapp/src/app/component/staffer/staffer.component.spec.ts
+++ b/src/main/webapp/src/app/component/staffer/staffer.component.spec.ts
@@ -1,0 +1,404 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {signal, WritableSignal} from '@angular/core';
+import {of, Subject, throwError} from 'rxjs';
+import {StafferComponent} from './staffer.component';
+import {StafferService} from '../../service/staffer.service';
+import {TeamService} from '../../service/team.service';
+import {RefereeService} from '../../service/referee.service';
+import {MatchService} from '../../service/match.service';
+import {UiSettingsService} from '../../service/ui-settings.service';
+import {Match} from '../../model/match';
+import {Team} from '../../model/team';
+import {Referee} from '../../model/referee';
+import {DifficultyBreakdown} from '../../model/difficultyBreakdown';
+
+describe('StafferComponent', () => {
+  let fixture: ComponentFixture<StafferComponent>;
+  let component: StafferComponent;
+  let stafferService: jasmine.SpyObj<StafferService>;
+  let teamService: jasmine.SpyObj<TeamService>;
+  let refereeService: jasmine.SpyObj<RefereeService>;
+  let matchService: jasmine.SpyObj<MatchService>;
+  let explainerVisible: WritableSignal<boolean>;
+
+  // Standings order defines place: index 0 = 1st. 8 teams, NUMBER_OF_EDGE_TEAMS = 3,
+  // so top = both places <= 3, bottom = both places > 5. Teams 1 and 2 share a city.
+  const standings: Team[] = [
+    {id: 1, name: 'Alfa', city: 'Krakow', points: 40},
+    {id: 2, name: 'Beta', city: 'Krakow', points: 35},
+    {id: 3, name: 'Gamma', city: 'Gdansk', points: 30},
+    {id: 4, name: 'Delta', city: 'Poznan', points: 25},
+    {id: 5, name: 'Epsilon', city: 'Lodz', points: 20},
+    {id: 6, name: 'Zeta', city: 'Wroclaw', points: 15},
+    {id: 7, name: 'Eta', city: 'Radom', points: 10},
+    {id: 8, name: 'Theta', city: 'Opole', points: 5}
+  ];
+
+  function makeMatch(id: number, overrides: Partial<Match> = {}): Match {
+    return {
+      id,
+      queue: 1,
+      homeTeamId: 1,
+      awayTeamId: 2,
+      date: new Date('2026-03-01T12:00:00'),
+      refereeId: undefined,
+      gradeId: undefined,
+      homeScore: undefined,
+      awayScore: undefined,
+      ...overrides
+    } as Match;
+  }
+
+  function makeReferee(id: number, overrides: Partial<Referee> = {}): Referee {
+    return {
+      id,
+      firstName: `First${id}`,
+      lastName: `Last${id}`,
+      email: `ref${id}@example.com`,
+      experience: 10,
+      ...overrides
+    };
+  }
+
+  const matches: Match[] = [
+    // Derby + top-3 (places 1 and 2, same city), hardest.
+    makeMatch(11, {homeTeamId: 1, awayTeamId: 2, refereeId: 100, hardnessLvl: 120.4}),
+    // Relegation (places 7 and 8), unassigned.
+    makeMatch(12, {homeTeamId: 7, awayTeamId: 8, hardnessLvl: 80.2}),
+    // Mid-table, no flags.
+    makeMatch(13, {homeTeamId: 4, awayTeamId: 5, refereeId: 101, hardnessLvl: 50})
+  ];
+
+  const referees: Referee[] = [
+    makeReferee(100, {potential: 90, experience: 10}),
+    makeReferee(101, {potential: 70, experience: 20}),
+    makeReferee(102, {experience: 5}), // un-enriched: no potential, sorts by experience
+    makeReferee(103, {potential: 95, experience: 15})
+  ];
+
+  function makeBreakdown(matchId: number): DifficultyBreakdown {
+    return {
+      matchId,
+      total: 120.4,
+      parts: {base: 90.4, sameCity: 15, top: 15, bottom: 0},
+      flags: {sameCity: true, isTop: true, isBot: false, pointsDiff: 5}
+    };
+  }
+
+  beforeEach(async () => {
+    stafferService = jasmine.createSpyObj('StafferService', ['staffReferees']);
+    teamService = jasmine.createSpyObj('TeamService', ['getStandings']);
+    refereeService = jasmine.createSpyObj('RefereeService', ['findRefereesAvailableForQueue']);
+    matchService = jasmine.createSpyObj('MatchService', ['getDifficultyBreakdown', 'updateList']);
+    explainerVisible = signal(false);
+
+    stafferService.staffReferees.and.returnValue(of(matches));
+    teamService.getStandings.and.returnValue(of(standings));
+    refereeService.findRefereesAvailableForQueue.and.returnValue(of(referees));
+    matchService.getDifficultyBreakdown.and.callFake(id => of(makeBreakdown(id)));
+    matchService.updateList.and.returnValue(of(void 0));
+
+    await TestBed.configureTestingModule({
+      imports: [StafferComponent],
+      providers: [
+        {provide: StafferService, useValue: stafferService},
+        {provide: TeamService, useValue: teamService},
+        {provide: RefereeService, useValue: refereeService},
+        {provide: MatchService, useValue: matchService},
+        {provide: UiSettingsService, useValue: {explainerVisible: explainerVisible.asReadonly()}}
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(StafferComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  describe('queue stepper', () => {
+    it('increments and decrements the queue', () => {
+      component.incQueue();
+      component.incQueue();
+      expect(component.queue()).toBe(3);
+      component.decQueue();
+      expect(component.queue()).toBe(2);
+    });
+
+    it('does not go below queue 1', () => {
+      component.decQueue();
+      component.decQueue();
+      expect(component.queue()).toBe(1);
+    });
+  });
+
+  describe('generate', () => {
+    it('staffs the selected queue and populates matches, referees and standings lookups', () => {
+      component.incQueue();
+      component.generate();
+
+      expect(stafferService.staffReferees).toHaveBeenCalledWith(2);
+      expect(refereeService.findRefereesAvailableForQueue).toHaveBeenCalledWith(2);
+      expect(component.matches()).toEqual(matches);
+      expect(component.referees()).toEqual(referees);
+      expect(component.totalTeams()).toBe(8);
+      expect(component.getTeam(1)?.name).toBe('Alfa');
+      expect(component.getTeam(999)).toBeUndefined();
+    });
+
+    it('keeps loading true until the forkJoin completes and clears it on success', () => {
+      const staffSubject = new Subject<Match[]>();
+      stafferService.staffReferees.and.returnValue(staffSubject);
+
+      component.generate();
+      expect(component.loading()).toBeTrue();
+
+      staffSubject.next(matches);
+      staffSubject.complete();
+      expect(component.loading()).toBeFalse();
+    });
+
+    it('clears loading and leaves matches untouched on error', () => {
+      stafferService.staffReferees.and.returnValue(throwError(() => new Error('boom')));
+
+      component.generate();
+
+      expect(component.loading()).toBeFalse();
+      expect(component.matches()).toBeNull();
+    });
+
+    it('resets the saved-at marker so a stale "Saved" note never shows for a new cast', () => {
+      component.generate();
+      component.save();
+      expect(component.savedAt()).not.toBeNull();
+
+      component.generate();
+      expect(component.savedAt()).toBeNull();
+    });
+  });
+
+  describe('derived state', () => {
+    beforeEach(() => component.generate());
+
+    it('sorts matches by difficulty descending', () => {
+      expect(component.sortedMatches().map(m => m.id)).toEqual([11, 12, 13]);
+    });
+
+    it('sums total difficulty rounded', () => {
+      // 120.4 + 80.2 + 50 = 250.6 -> 251
+      expect(component.totalDifficulty()).toBe(251);
+    });
+  });
+
+  describe('locks', () => {
+    beforeEach(() => component.generate());
+
+    it('locks and unlocks an assigned match', () => {
+      const assigned = component.matches()![0];
+
+      component.toggleLock(assigned);
+      expect(component.isLocked(assigned)).toBeTrue();
+      expect(component.lockCount()).toBe(1);
+
+      component.toggleLock(assigned);
+      expect(component.isLocked(assigned)).toBeFalse();
+      expect(component.lockCount()).toBe(0);
+    });
+
+    it('ignores locking a match without an assigned referee', () => {
+      const unassigned = component.matches()!.find(m => m.id === 12)!;
+
+      component.toggleLock(unassigned);
+
+      expect(component.isLocked(unassigned)).toBeFalse();
+      expect(component.lockCount()).toBe(0);
+    });
+
+    it('clears all locks at once', () => {
+      component.toggleLock(component.matches()![0]);
+      component.toggleLock(component.matches()![2]);
+      expect(component.lockCount()).toBe(2);
+
+      component.clearLocks();
+      expect(component.lockCount()).toBe(0);
+    });
+  });
+
+  describe('swap', () => {
+    beforeEach(() => component.generate());
+
+    it('reassigns the referee immutably and locks the match', () => {
+      const before = component.matches()!;
+      const target = before.find(m => m.id === 12)!;
+
+      component.swap(target, 102);
+
+      const after = component.matches()!;
+      expect(after).not.toBe(before);
+      expect(after.find(m => m.id === 12)!.refereeId).toBe(102);
+      expect(before.find(m => m.id === 12)!.refereeId).toBeUndefined();
+      expect(component.isLocked(target)).toBeTrue();
+      expect(component.locks().get(12)).toBe(102);
+    });
+
+    it('invalidates the saved-at marker', () => {
+      component.save();
+      expect(component.savedAt()).not.toBeNull();
+
+      component.swap(component.matches()![0], 103);
+      expect(component.savedAt()).toBeNull();
+    });
+  });
+
+  describe('drawer', () => {
+    beforeEach(() => component.generate());
+
+    it('opens with the clicked match and lazily loads its breakdown', () => {
+      const target = component.matches()![0];
+
+      component.openDrawer(target);
+
+      expect(component.drawerMatch()).toEqual(target);
+      expect(matchService.getDifficultyBreakdown).toHaveBeenCalledWith(11);
+      expect(component.drawerBreakdown()?.matchId).toBe(11);
+    });
+
+    it('discards a stale breakdown response after switching to another match', () => {
+      const first = new Subject<DifficultyBreakdown>();
+      const second = new Subject<DifficultyBreakdown>();
+      matchService.getDifficultyBreakdown.and.returnValues(first, second);
+      const [m1, m2] = component.matches()!;
+
+      component.openDrawer(m1);
+      component.openDrawer(m2);
+
+      first.next(makeBreakdown(m1.id));
+      expect(component.drawerBreakdown()).toBeNull();
+
+      second.next(makeBreakdown(m2.id));
+      expect(component.drawerBreakdown()?.matchId).toBe(m2.id);
+    });
+
+    it('closes and resets the breakdown', () => {
+      component.openDrawer(component.matches()![0]);
+
+      component.closeDrawer();
+
+      expect(component.drawerMatch()).toBeNull();
+      expect(component.drawerBreakdown()).toBeNull();
+    });
+  });
+
+  describe('candidatesFor', () => {
+    beforeEach(() => component.generate());
+
+    it('sorts by potential descending with experience fallback for un-enriched referees', () => {
+      const target = component.matches()!.find(m => m.id === 12)!;
+
+      const ids = component.candidatesFor(target).map(c => c.referee.id);
+
+      // potentials: 103 -> 95, 100 -> 90, 101 -> 70; 102 falls back to experience 5.
+      expect(ids).toEqual([103, 100, 101, 102]);
+    });
+
+    it('flags the assigned referee and referees used by other matches in the queue', () => {
+      const target = component.matches()!.find(m => m.id === 11)!;
+
+      const candidates = component.candidatesFor(target);
+      const byId = new Map(candidates.map(c => [c.referee.id, c]));
+
+      expect(byId.get(100)!.isAssigned).toBeTrue();
+      expect(byId.get(100)!.isUsedElsewhere).toBeFalse();
+      expect(byId.get(101)!.isUsedElsewhere).toBeTrue();
+      expect(byId.get(102)!.isUsedElsewhere).toBeFalse();
+      expect(byId.get(103)!.isUsedElsewhere).toBeFalse();
+    });
+  });
+
+  describe('flags', () => {
+    beforeEach(() => component.generate());
+
+    it('marks a same-city top-3 pairing as derby and top', () => {
+      const flags = component.flags(makeMatch(21, {homeTeamId: 1, awayTeamId: 2}));
+      expect(flags).toEqual({sameCity: true, isTop: true, isBot: false});
+    });
+
+    it('marks a pairing of the bottom three as relegation', () => {
+      const flags = component.flags(makeMatch(22, {homeTeamId: 7, awayTeamId: 8}));
+      expect(flags).toEqual({sameCity: false, isTop: false, isBot: true});
+    });
+
+    it('requires both teams inside the edge zone', () => {
+      // Places 3 vs 4: only home side is top-3. Places 5 vs 8: only away side is bottom-3.
+      expect(component.flags(makeMatch(23, {homeTeamId: 3, awayTeamId: 4})).isTop).toBeFalse();
+      expect(component.flags(makeMatch(24, {homeTeamId: 5, awayTeamId: 8})).isBot).toBeFalse();
+    });
+
+    it('treats the zone boundaries as inclusive', () => {
+      // Places 1 vs 3 are both <= 3; places 6 vs 8 are both > 8 - 3.
+      expect(component.flags(makeMatch(25, {homeTeamId: 1, awayTeamId: 3})).isTop).toBeTrue();
+      expect(component.flags(makeMatch(26, {homeTeamId: 6, awayTeamId: 8})).isBot).toBeTrue();
+    });
+
+    it('reports no flags for a mid-table cross-city pairing', () => {
+      expect(component.hasNoFlags(makeMatch(27, {homeTeamId: 4, awayTeamId: 5}))).toBeTrue();
+    });
+
+    it('degrades to no flags for teams missing from the standings', () => {
+      expect(component.hasNoFlags(makeMatch(28, {homeTeamId: 998, awayTeamId: 999}))).toBeTrue();
+    });
+  });
+
+  describe('save', () => {
+    it('sends the current cast and stamps the save time', () => {
+      component.generate();
+
+      component.save();
+
+      expect(matchService.updateList).toHaveBeenCalledWith(component.matches()!);
+      expect(component.savedAt()).toBeInstanceOf(Date);
+    });
+
+    it('does nothing before a cast is generated', () => {
+      component.save();
+
+      expect(matchService.updateList).not.toHaveBeenCalled();
+      expect(component.savedAt()).toBeNull();
+    });
+  });
+
+  describe('difficultyKind', () => {
+    it('warns from 100 upward and defaults below or when missing', () => {
+      expect(component.difficultyKind(99.9)).toBe('default');
+      expect(component.difficultyKind(100)).toBe('warn');
+      expect(component.difficultyKind(null)).toBe('default');
+      expect(component.difficultyKind(undefined)).toBe('default');
+    });
+  });
+
+  describe('template', () => {
+    it('shows the empty state until a cast is generated', () => {
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.querySelector('.empty-state')).not.toBeNull();
+      expect(el.querySelector('.panel--kpi-strip')).toBeNull();
+    });
+
+    it('renders the KPI strip and one row per match after generating', () => {
+      const el: HTMLElement = fixture.nativeElement;
+      (el.querySelector('.page-head__actions .btn--primary') as HTMLButtonElement).click();
+      fixture.detectChanges();
+
+      expect(el.querySelector('.empty-state')).toBeNull();
+      expect(el.querySelector('.panel--kpi-strip')).not.toBeNull();
+      expect(el.querySelectorAll('tr.cast-row').length).toBe(3);
+    });
+
+    it('gates the algorithm explainer on the UI setting', () => {
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.querySelector('.explainer')).toBeNull();
+
+      explainerVisible.set(true);
+      fixture.detectChanges();
+
+      expect(el.querySelector('.explainer')).not.toBeNull();
+    });
+  });
+});

--- a/src/main/webapp/src/app/component/standings/standings.component.spec.ts
+++ b/src/main/webapp/src/app/component/standings/standings.component.spec.ts
@@ -1,0 +1,109 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {of} from 'rxjs';
+import {StandingsComponent} from './standings.component';
+import {TeamService} from '../../service/team.service';
+import {MatchService} from '../../service/match.service';
+import {Team} from '../../model/team';
+import {Match} from '../../model/match';
+
+describe('StandingsComponent', () => {
+  let teamService: jasmine.SpyObj<TeamService>;
+  let matchService: jasmine.SpyObj<MatchService>;
+
+  // /api/teams/standings returns table order; 8 teams so both edge zones exist.
+  const standings: Team[] = Array.from({length: 8}, (_, i) => ({
+    id: i + 1, name: `Team ${i + 1}`, city: `City ${i + 1}`, points: 40 - i * 5
+  }));
+
+  const matches = [
+    // Team 1 beats Team 2 away: 1 has W 3:1, 2 has L.
+    {id: 11, queue: 1, homeTeamId: 2, awayTeamId: 1, homeScore: 1, awayScore: 3},
+    // Draw between 1 and 3.
+    {id: 12, queue: 2, homeTeamId: 1, awayTeamId: 3, homeScore: 2, awayScore: 2},
+    // Unplayed — must not count anywhere.
+    {id: 13, queue: 3, homeTeamId: 1, awayTeamId: 4}
+  ] as Match[];
+
+  beforeEach(async () => {
+    teamService = jasmine.createSpyObj('TeamService', ['getStandings']);
+    matchService = jasmine.createSpyObj('MatchService', ['findAll']);
+    teamService.getStandings.and.returnValue(of(standings));
+    matchService.findAll.and.returnValue(of(matches));
+
+    await TestBed.configureTestingModule({
+      imports: [StandingsComponent],
+      providers: [
+        {provide: TeamService, useValue: teamService},
+        {provide: MatchService, useValue: matchService}
+      ]
+    }).compileComponents();
+  });
+
+  function create(): ComponentFixture<StandingsComponent> {
+    const fixture = TestBed.createComponent(StandingsComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('derives W/D/L and goals from played matches only', () => {
+    const rows = create().componentInstance.rows();
+    const team1 = rows.find(r => r.team.id === 1)!;
+    const team2 = rows.find(r => r.team.id === 2)!;
+    const team4 = rows.find(r => r.team.id === 4)!;
+
+    expect(team1).toEqual(jasmine.objectContaining(
+      {played: 2, wins: 1, draws: 1, losses: 0, goalsFor: 5, goalsAgainst: 3}));
+    expect(team2).toEqual(jasmine.objectContaining(
+      {played: 1, wins: 0, draws: 0, losses: 1, goalsFor: 1, goalsAgainst: 3}));
+    // Only fixture 13 references team 4 and it has no result.
+    expect(team4.played).toBe(0);
+  });
+
+  it('marks the top three accent and the bottom three danger', () => {
+    const rows = create().componentInstance.rows();
+
+    expect(rows.filter(r => r.zone === 'accent').map(r => r.pos)).toEqual([1, 2, 3]);
+    expect(rows.filter(r => r.zone === 'danger').map(r => r.pos)).toEqual([6, 7, 8]);
+    expect(rows.filter(r => r.zone === null).map(r => r.pos)).toEqual([4, 5]);
+  });
+
+  it('suppresses the danger zone in a league too small for both zones', () => {
+    teamService.getStandings.and.returnValue(of(standings.slice(0, 5)));
+
+    const rows = create().componentInstance.rows();
+
+    expect(rows.filter(r => r.zone === 'accent').map(r => r.pos)).toEqual([1, 2, 3]);
+    expect(rows.some(r => r.zone === 'danger')).toBeFalse();
+  });
+
+  it('formats the goal difference with an explicit sign', () => {
+    const component = create().componentInstance;
+    const rows = component.rows();
+    const team1 = rows.find(r => r.team.id === 1)!; // GD +2
+    const team2 = rows.find(r => r.team.id === 2)!; // GD -2
+    const team3 = rows.find(r => r.team.id === 3)!; // GD 0
+
+    expect(component.formatGoalDiff(team1)).toBe('+2');
+    expect(component.formatGoalDiff(team2)).toBe('-2');
+    expect(component.formatGoalDiff(team3)).toBe('0');
+  });
+
+  it('filters the visible rows by zone segment', () => {
+    const component = create().componentInstance;
+
+    expect(component.visibleRows().length).toBe(8);
+
+    component.filter.set('top');
+    expect(component.visibleRows().map(r => r.pos)).toEqual([1, 2, 3, 4, 5, 6]);
+
+    component.filter.set('bottom');
+    expect(component.visibleRows().map(r => r.pos)).toEqual([6, 7, 8]);
+  });
+
+  it('reports the latest queue with a played match, or null before the season starts', () => {
+    expect(create().componentInstance.latestPlayedQueue()).toBe(2);
+
+    matchService.findAll.and.returnValue(of([matches[2]]));
+    expect(create().componentInstance.latestPlayedQueue()).toBeNull();
+  });
+});

--- a/src/main/webapp/src/app/component/team-form/team-form.component.spec.ts
+++ b/src/main/webapp/src/app/component/team-form/team-form.component.spec.ts
@@ -1,0 +1,78 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {NgForm} from '@angular/forms';
+import {of} from 'rxjs';
+import {TeamFormComponent} from './team-form.component';
+import {TeamService} from '../../service/team.service';
+import {Team} from '../../model/team';
+
+describe('TeamFormComponent', () => {
+  let teamService: jasmine.SpyObj<TeamService>;
+
+  const existing: Team = {id: 3, name: 'Alfa', city: 'Krakow', points: 40, short: 'ALF'};
+  const validForm = {valid: true} as NgForm;
+
+  beforeEach(async () => {
+    teamService = jasmine.createSpyObj('TeamService', ['save', 'update']);
+    await TestBed.configureTestingModule({
+      imports: [TeamFormComponent],
+      providers: [{provide: TeamService, useValue: teamService}]
+    }).compileComponents();
+  });
+
+  function create(team: Team | null): ComponentFixture<TeamFormComponent> {
+    const fixture = TestBed.createComponent(TeamFormComponent);
+    fixture.componentInstance.team = team;
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('starts empty in add mode', () => {
+    const component = create(null).componentInstance;
+
+    expect(component.editMode).toBeFalse();
+    expect(component.subtitle).toBe('New club in the league');
+    expect(component.model).toEqual({name: '', city: ''});
+  });
+
+  it('copies only name and city in edit mode', () => {
+    const component = create(existing).componentInstance;
+
+    expect(component.editMode).toBeTrue();
+    expect(component.subtitle).toBe('Alfa');
+    expect(component.model).toEqual({name: 'Alfa', city: 'Krakow'});
+  });
+
+  it('ignores submit while the form is invalid', () => {
+    create(null).componentInstance.onSubmit({valid: false} as NgForm);
+
+    expect(teamService.save).not.toHaveBeenCalled();
+    expect(teamService.update).not.toHaveBeenCalled();
+  });
+
+  it('saves a new team and emits the backend response', () => {
+    const component = create(null).componentInstance;
+    const saved: Team = {id: 10, name: 'Beta', city: 'Gdansk', points: 0};
+    teamService.save.and.returnValue(of(saved));
+    const emitted: Team[] = [];
+    component.saved.subscribe(t => emitted.push(t));
+
+    component.model = {name: 'Beta', city: 'Gdansk'};
+    component.onSubmit(validForm);
+
+    expect(teamService.save).toHaveBeenCalledWith(jasmine.objectContaining({name: 'Beta', city: 'Gdansk'}));
+    expect(emitted).toEqual([saved]);
+  });
+
+  it('updates on edit with the backend-owned fields riding along in the payload', () => {
+    const component = create(existing).componentInstance;
+    teamService.update.and.returnValue(of(existing));
+
+    component.model.city = 'Wieliczka';
+    component.onSubmit(validForm);
+
+    expect(teamService.update).toHaveBeenCalledWith(jasmine.objectContaining({
+      id: 3, name: 'Alfa', city: 'Wieliczka', points: 40, short: 'ALF'
+    }));
+    expect(teamService.save).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/webapp/src/app/component/team-list/team-list.component.spec.ts
+++ b/src/main/webapp/src/app/component/team-list/team-list.component.spec.ts
@@ -1,0 +1,135 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ActivatedRoute, convertToParamMap, Router} from '@angular/router';
+import {of} from 'rxjs';
+import {TeamListComponent} from './team-list.component';
+import {TeamService} from '../../service/team.service';
+import {MatchService} from '../../service/match.service';
+import {Team} from '../../model/team';
+import {Match} from '../../model/match';
+
+describe('TeamListComponent', () => {
+  let teamService: jasmine.SpyObj<TeamService>;
+  let matchService: jasmine.SpyObj<MatchService>;
+  let router: jasmine.SpyObj<Router>;
+
+  const standings: Team[] = [
+    {id: 1, name: 'Alfa', city: 'Krakow', points: 40},
+    {id: 2, name: 'Beta', city: 'Gdansk', points: 20},
+    {id: 3, name: 'Gamma', city: 'Krakow', points: 10}
+  ];
+
+  const matches = [
+    {id: 11, queue: 1, homeTeamId: 1, awayTeamId: 2, homeScore: 2, awayScore: 1},
+    {id: 12, queue: 1, homeTeamId: 3, awayTeamId: 1, homeScore: 0, awayScore: 0},
+    // No result yet — must not count as played.
+    {id: 13, queue: 2, homeTeamId: 2, awayTeamId: 3}
+  ] as Match[];
+
+  beforeEach(() => {
+    teamService = jasmine.createSpyObj('TeamService', ['getStandings', 'findById', 'delete']);
+    matchService = jasmine.createSpyObj('MatchService', ['findAll']);
+    router = jasmine.createSpyObj('Router', ['navigate']);
+
+    teamService.getStandings.and.returnValue(of(standings));
+    matchService.findAll.and.returnValue(of(matches));
+  });
+
+  async function create(path = 'teams', id?: number): Promise<ComponentFixture<TeamListComponent>> {
+    await TestBed.configureTestingModule({
+      imports: [TeamListComponent],
+      providers: [
+        {provide: TeamService, useValue: teamService},
+        {provide: MatchService, useValue: matchService},
+        {provide: Router, useValue: router},
+        {
+          provide: ActivatedRoute,
+          useValue: {snapshot: {url: [{path}], paramMap: convertToParamMap(id ? {id: String(id)} : {})}}
+        }
+      ]
+    }).compileComponents();
+    const fixture = TestBed.createComponent(TeamListComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('renders the standings order and derives played from finished matches only', async () => {
+    const fixture = await create();
+    const component = fixture.componentInstance;
+
+    expect(component.teams().map(t => t.id)).toEqual([1, 2, 3]);
+    expect(component.played(standings[0])).toBe(2);
+    expect(component.played(standings[1])).toBe(1); // fixture 13 has no score
+    expect(component.played(standings[2])).toBe(1);
+    expect((fixture.nativeElement as HTMLElement).querySelectorAll('tbody tr').length).toBe(3);
+  });
+
+  it('filters by name or city', async () => {
+    const component = (await create()).componentInstance;
+
+    component.setSearch('krakow');
+    expect(component.visibleTeams().map(t => t.id)).toEqual([1, 3]);
+
+    component.setSearch('beta');
+    expect(component.visibleTeams().map(t => t.id)).toEqual([2]);
+  });
+
+  it('scales the points bar to the leader', async () => {
+    const component = (await create()).componentInstance;
+
+    expect(component.barPct(standings[0])).toBe(100);
+    expect(component.barPct(standings[1])).toBe(50);
+  });
+
+  it('deletes only after the confirm, naming the team in the guard', async () => {
+    const component = (await create()).componentInstance;
+    teamService.delete.and.returnValue(of(void 0));
+
+    component.askDelete(standings[1]);
+    expect(component.deleteGuard().message).toContain('Beta');
+    expect(teamService.delete).not.toHaveBeenCalled();
+
+    component.confirmDelete();
+
+    expect(teamService.delete).toHaveBeenCalledWith(2);
+    expect(component.teams().map(t => t.id)).toEqual([1, 3]);
+    expect(component.deleteTarget()).toBeNull();
+  });
+
+  describe('deep links', () => {
+    it('opens an empty drawer for /addTeam', async () => {
+      const component = (await create('addTeam')).componentInstance;
+
+      expect(component.formOpen()).toBeTrue();
+      expect(component.editingTeam()).toBeNull();
+    });
+
+    it('fetches the team and opens the edit drawer for /addTeam/:id', async () => {
+      teamService.findById.and.returnValue(of(standings[0]));
+
+      const component = (await create('addTeam', 1)).componentInstance;
+
+      expect(teamService.findById).toHaveBeenCalledWith(1);
+      expect(component.editingTeam()).toEqual(standings[0]);
+      expect(component.formOpen()).toBeTrue();
+    });
+
+    it('normalizes the URL back to the list on close only when deep-linked', async () => {
+      const component = (await create('addTeam')).componentInstance;
+
+      component.closeForm();
+
+      expect(router.navigate).toHaveBeenCalledWith(['/teams']);
+    });
+  });
+
+  it('reloads the table after a save and closes the drawer', async () => {
+    const component = (await create()).componentInstance;
+    component.addTeam();
+    teamService.getStandings.calls.reset();
+
+    component.onSaved();
+
+    expect(teamService.getStandings).toHaveBeenCalledTimes(1);
+    expect(component.formOpen()).toBeFalse();
+  });
+});

--- a/src/main/webapp/src/app/component/vacation-form/vacation-form.component.spec.ts
+++ b/src/main/webapp/src/app/component/vacation-form/vacation-form.component.spec.ts
@@ -1,0 +1,130 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {NgForm} from '@angular/forms';
+import {of} from 'rxjs';
+import {VacationFormComponent} from './vacation-form.component';
+import {VacationService} from '../../service/vacation.service';
+import {RefereeService} from '../../service/referee.service';
+import {Vacation} from '../../model/vacation';
+import {Referee} from '../../model/referee';
+
+describe('VacationFormComponent', () => {
+  let vacationService: jasmine.SpyObj<VacationService>;
+  let refereeService: jasmine.SpyObj<RefereeService>;
+
+  const referees: Referee[] = [
+    {id: 1, firstName: 'Zenon', lastName: 'Zielinski', email: 'z@example.com', experience: 5},
+    {id: 2, firstName: 'Adam', lastName: 'Adamski', email: 'a@example.com', experience: 8}
+  ];
+
+  // Native date inputs bind ISO strings, not Date objects — mirror that in the fixture.
+  const existing = {
+    id: 4, refereeId: 2, startDate: '2026-08-01', endDate: '2026-08-14'
+  } as unknown as Vacation;
+
+  const validForm = {valid: true} as NgForm;
+
+  beforeEach(async () => {
+    vacationService = jasmine.createSpyObj('VacationService', ['save', 'update']);
+    refereeService = jasmine.createSpyObj('RefereeService', ['findAll']);
+    refereeService.findAll.and.returnValue(of(referees));
+
+    await TestBed.configureTestingModule({
+      imports: [VacationFormComponent],
+      providers: [
+        {provide: VacationService, useValue: vacationService},
+        {provide: RefereeService, useValue: refereeService}
+      ]
+    }).compileComponents();
+  });
+
+  function create(vacation: Vacation | null): ComponentFixture<VacationFormComponent> {
+    const fixture = TestBed.createComponent(VacationFormComponent);
+    fixture.componentInstance.vacation = vacation;
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('sorts the referee select by last name', () => {
+    const component = create(null).componentInstance;
+
+    expect(component.referees.map(r => r.lastName)).toEqual(['Adamski', 'Zielinski']);
+  });
+
+  it('copies the edited vacation into the model', () => {
+    const component = create(existing).componentInstance;
+
+    expect(component.editMode).toBeTrue();
+    expect(component.model).toEqual({refereeId: 2, startDate: '2026-08-01', endDate: '2026-08-14'} as unknown as typeof component.model);
+  });
+
+  describe('endBeforeStart', () => {
+    it('is false while either date is missing', () => {
+      const component = create(null).componentInstance;
+      expect(component.endBeforeStart).toBeFalse();
+
+      component.model.startDate = '2026-08-01' as unknown as Date;
+      expect(component.endBeforeStart).toBeFalse();
+    });
+
+    it('is true only when the end is strictly before the start', () => {
+      const component = create(null).componentInstance;
+      component.model.startDate = '2026-08-10' as unknown as Date;
+
+      component.model.endDate = '2026-08-09' as unknown as Date;
+      expect(component.endBeforeStart).toBeTrue();
+
+      // A one-day vacation (start == end) is valid.
+      component.model.endDate = '2026-08-10' as unknown as Date;
+      expect(component.endBeforeStart).toBeFalse();
+    });
+  });
+
+  describe('onSubmit', () => {
+    it('ignores an invalid form', () => {
+      create(null).componentInstance.onSubmit({valid: false} as NgForm);
+
+      expect(vacationService.save).not.toHaveBeenCalled();
+      expect(vacationService.update).not.toHaveBeenCalled();
+    });
+
+    it('blocks a reversed date range even when Angular validators pass', () => {
+      const component = create(null).componentInstance;
+      component.model = {
+        refereeId: 1, startDate: '2026-08-10', endDate: '2026-08-01'
+      } as unknown as typeof component.model;
+
+      component.onSubmit(validForm);
+
+      expect(vacationService.save).not.toHaveBeenCalled();
+    });
+
+    it('saves a new vacation and emits the backend response', () => {
+      const component = create(null).componentInstance;
+      const saved = {...existing, id: 77};
+      vacationService.save.and.returnValue(of(saved));
+      const emitted: Vacation[] = [];
+      component.saved.subscribe(v => emitted.push(v));
+
+      component.model = {
+        refereeId: 1, startDate: '2026-08-01', endDate: '2026-08-05'
+      } as unknown as typeof component.model;
+      component.onSubmit(validForm);
+
+      expect(vacationService.save).toHaveBeenCalledWith(jasmine.objectContaining({refereeId: 1}));
+      expect(emitted).toEqual([saved]);
+    });
+
+    it('updates on edit, keeping the id from the original vacation', () => {
+      const component = create(existing).componentInstance;
+      vacationService.update.and.returnValue(of(existing));
+
+      component.model.endDate = '2026-08-20' as unknown as Date;
+      component.onSubmit(validForm);
+
+      expect(vacationService.update).toHaveBeenCalledWith(jasmine.objectContaining({
+        id: 4, refereeId: 2, endDate: '2026-08-20'
+      }));
+      expect(vacationService.save).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/main/webapp/src/app/component/vacation-list/vacation-list.component.spec.ts
+++ b/src/main/webapp/src/app/component/vacation-list/vacation-list.component.spec.ts
@@ -1,0 +1,144 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ActivatedRoute, convertToParamMap, Router} from '@angular/router';
+import {of} from 'rxjs';
+import {VacationListComponent} from './vacation-list.component';
+import {VacationService} from '../../service/vacation.service';
+import {RefereeService} from '../../service/referee.service';
+import {Vacation} from '../../model/vacation';
+import {Referee} from '../../model/referee';
+
+describe('VacationListComponent', () => {
+  let vacationService: jasmine.SpyObj<VacationService>;
+  let refereeService: jasmine.SpyObj<RefereeService>;
+  let router: jasmine.SpyObj<Router>;
+
+  const referees: Referee[] = [
+    {id: 1, firstName: 'Jan', lastName: 'Kowalski', email: 'jan@example.com', experience: 10},
+    {id: 2, firstName: 'Anna', lastName: 'Nowak', email: 'anna@example.com', experience: 20}
+  ];
+
+  /** yyyy-MM-dd in local time, offset by `days` from today. */
+  function isoDay(offsetDays: number): string {
+    const d = new Date();
+    d.setDate(d.getDate() + offsetDays);
+    const month = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${d.getFullYear()}-${month}-${day}`;
+  }
+
+  function makeVacation(id: number, refereeId: number, startDate: string, endDate: string): Vacation {
+    return {id, refereeId, startDate, endDate} as unknown as Vacation;
+  }
+
+  const past = makeVacation(31, 1, isoDay(-10), isoDay(-5));
+  const active = makeVacation(32, 2, isoDay(-1), isoDay(1));
+  const upcoming = makeVacation(33, 1, isoDay(5), isoDay(8));
+
+  beforeEach(() => {
+    vacationService = jasmine.createSpyObj('VacationService', ['findAll', 'findById', 'delete']);
+    refereeService = jasmine.createSpyObj('RefereeService', ['findByIds', 'findAll']);
+    router = jasmine.createSpyObj('Router', ['navigate']);
+
+    vacationService.findAll.and.returnValue(of([upcoming, past, active]));
+    refereeService.findByIds.and.returnValue(of(referees));
+    // The vacation form (rendered when the drawer opens) loads the pool on init.
+    refereeService.findAll.and.returnValue(of(referees));
+  });
+
+  async function create(path = 'vacations', id?: number): Promise<ComponentFixture<VacationListComponent>> {
+    await TestBed.configureTestingModule({
+      imports: [VacationListComponent],
+      providers: [
+        {provide: VacationService, useValue: vacationService},
+        {provide: RefereeService, useValue: refereeService},
+        {provide: Router, useValue: router},
+        {
+          provide: ActivatedRoute,
+          useValue: {snapshot: {url: [{path}], paramMap: convertToParamMap(id ? {id: String(id)} : {})}}
+        }
+      ]
+    }).compileComponents();
+    const fixture = TestBed.createComponent(VacationListComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('sorts by start date and joins the referees once by their unique ids', async () => {
+    const fixture = await create();
+    const component = fixture.componentInstance;
+
+    expect(component.sortedVacations().map(v => v.id)).toEqual([31, 32, 33]);
+    // Referee 1 owns two windows — the lookup must deduplicate.
+    expect(refereeService.findByIds).toHaveBeenCalledWith([1, 2]);
+    expect(component.getReferee(2)?.lastName).toBe('Nowak');
+    expect((fixture.nativeElement as HTMLElement).querySelectorAll('tbody tr').length).toBe(3);
+  });
+
+  it('clears the referee lookup when there are no vacations', async () => {
+    vacationService.findAll.and.returnValue(of([]));
+
+    const component = (await create()).componentInstance;
+
+    expect(refereeService.findByIds).not.toHaveBeenCalled();
+    expect(component.refereesById().size).toBe(0);
+  });
+
+  it('derives the status from today against the window', async () => {
+    const component = (await create()).componentInstance;
+
+    expect(component.status(past)).toBe('past');
+    expect(component.status(active)).toBe('active');
+    expect(component.status(upcoming)).toBe('upcoming');
+    // Boundary days are inclusive — a window starting or ending today is active.
+    expect(component.status(makeVacation(41, 1, isoDay(0), isoDay(3)))).toBe('active');
+    expect(component.status(makeVacation(42, 1, isoDay(-3), isoDay(0)))).toBe('active');
+  });
+
+  it('counts days inclusively', async () => {
+    const component = (await create()).componentInstance;
+
+    expect(component.days(makeVacation(51, 1, '2026-08-01', '2026-08-01'))).toBe(1);
+    expect(component.days(makeVacation(52, 1, '2026-08-01', '2026-08-14'))).toBe(14);
+  });
+
+  it('deletes only after the confirm, naming the owner in the guard', async () => {
+    const component = (await create()).componentInstance;
+    vacationService.delete.and.returnValue(of(void 0));
+
+    component.askDelete(active);
+    expect(component.deleteGuard().message).toContain("Anna Nowak's vacation");
+
+    component.confirmDelete();
+
+    expect(vacationService.delete).toHaveBeenCalledWith(32);
+    expect(component.vacations().map(v => v.id)).not.toContain(32);
+    expect(component.deleteTarget()).toBeNull();
+  });
+
+  describe('deep links', () => {
+    it('opens an empty drawer for /addVacation', async () => {
+      const component = (await create('addVacation')).componentInstance;
+
+      expect(component.formOpen()).toBeTrue();
+      expect(component.editingVacation()).toBeNull();
+    });
+
+    it('fetches the vacation and opens the edit drawer for /addVacation/:id', async () => {
+      vacationService.findById.and.returnValue(of(past));
+
+      const component = (await create('addVacation', 31)).componentInstance;
+
+      expect(vacationService.findById).toHaveBeenCalledWith(31);
+      expect(component.editingVacation()).toEqual(past);
+      expect(component.formOpen()).toBeTrue();
+    });
+
+    it('normalizes the URL back to the list on close only when deep-linked', async () => {
+      const component = (await create('addVacation')).componentInstance;
+
+      component.closeForm();
+
+      expect(router.navigate).toHaveBeenCalledWith(['/vacations']);
+    });
+  });
+});


### PR DESCRIPTION
## Ticket

[RS-81 — Testy komponentów: najpierw staffer i match-form (hot-spoty), potem reszta](https://referee-staffer.youtrack.cloud/issue/RS-81)

The redesigned UI layer (2026-06) shipped with no component tests at all — the only existing frontend spec was a trivial pipe instantiation check. This PR covers the ticket's full list, in its risk order:

1. **`staffer.component`** — the core feature of the app (generate/lock/swap/save on signals), previously zero coverage.
2. **`match-form`** — the grade save/update/delete decision tree carried over verbatim from the legacy routed form, the most fragile data-flow in the UI.
3. **Entity form drawers** (referee / team / vacation).
4. **Overlay atoms** (`drawer`, `form-drawer`, `confirm-dialog`).
5. **Lists** (referee / match / team / vacation) incl. the legacy deep links.
6. **`standings`, `vacation-list` statuses, `importer`, `shell`.**

## Plan

1. Branch off `origin/master`, no production-code changes — tests only.
2. Hot-spots first: `staffer.component.spec.ts` (TestBed, services as Jasmine spies — `of(...)` for happy paths, `Subject` wherever emission *timing* is under test: loading lifecycle, the drawer's stale-response race guard) and `match-form.component.spec.ts` (the full four-way grade decision tree, each branch asserting the single right grade operation and that `saved` emits only after the grade round-trip).
3. Then the rest of the ticket list:
   - **Forms**: init in add vs edit mode (model is a *copy*; enriched/backend-owned fields ride along via the payload spread), invalid-form short-circuit, save-vs-update dispatch; for referee-form also DOM-level `fakeAsync` checks that errors gate on touched/dirty, the strict email pattern rejects TLD-less addresses, and the footer submit enables only when everything is valid; for vacation-form the `endBeforeStart` rule (missing dates, strict inequality, submit block).
   - **Overlays**: render-nothing-while-closed, X/backdrop/Esc all emit, Esc only while open; form-drawer's submit `form`-attribute wiring + validity gating, dirty indicator, and the discard guard (clean close vs guarded close, confirm closes, cancel keeps editing, and a single document-level Escape dismisses only the guard — the drawer's `tryClose()` must no-op while the guard is up).
   - **Lists**: load + join assertions (match-list joins only the ids actually referenced and skips empty lookups), ranking/filtering computeds, delete-through-confirm (guard names the entity; service called only on confirm), deep links `/addX` and `/addX/:id` opening the drawer, and URL normalization on close only when deep-linked.
   - **Standings**: W/D/L/GF/GA derived from finished matches only, accent/danger zones with the small-league suppression, signed goal-difference formatting, segment filters, latest played queue.
   - **Vacation statuses** (past/active/upcoming with inclusive boundary days), **importer** upload lifecycle (guards, uploading flag, error surface + retry reset), **shell** (Admin nav group gated on the UI setting, temporary toggle labels, explainer toggle placement, theme button).
4. Verify with `npm ci`, `npm run lint`, headless Karma run; self-review the diff.

## Changes

15 new spec files, 137 tests total (136 new + 1 pre-existing pipe spec). No production code touched.

Design decisions:

- **Spies over `HttpTestingController`** — the services are one-liner HTTP wrappers; mocking at the service boundary keeps the specs about component behaviour, not URL strings, and matches how the backend Spock controller specs isolate their layer.
- **`Subject`-driven assertions for async ordering** — loading flags, the staffer drawer race guard, and the saved-emits-after-grade contract are all about *when* things happen, so those specs hold the response open instead of using `of(...)`.
- **`componentRef.setInput` for input changes after the first change-detection pass** — direct instance mutation leaves the view unmarked and trips `NG0100` on the dev-mode `checkNoChanges` pass (all seven form-drawer specs failed that way on the first run).
- **Stubbed `UiSettingsService`** (writable signals + spies) wherever it's injected, so specs don't touch `localStorage`/`document` theme state.
- **Route stubs per test** — lists get a minimal `ActivatedRoute` snapshot (`url[0].path` + `paramMap`), which is all the deep-link logic reads, and a `Router` spy to assert URL normalization without a real router.
- **Real dates for vacation statuses** — `status()` compares against today, so the fixtures build ISO dates relative to `new Date()` instead of pinning the clock.

## Testing

- `npm run lint` — clean.
- `CHROME_BIN=… ng test --browsers=ChromeHeadlessNoSandbox --watch=false` — **137/137 SUCCESS**.
- Backend untouched; `frontend.yml` CI runs the same lint + headless test commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdSsSkQfeWTTTa4R141b17