### PR TITLE
RS-7: Support split observer grades with mean-based effective value

### DIFF
--- a/src/main/java/com/jamex/refereestaffer/RefereeStafferApplication.java
+++ b/src/main/java/com/jamex/refereestaffer/RefereeStafferApplication.java
@@ -56,7 +56,7 @@ public class RefereeStafferApplication {
 
             var grade1 = new Grade(match1, 8.3);
             var grade2 = new Grade(match2, 8.2);
-            var grade3 = new Grade(match3, 7.9);
+            var grade3 = new Grade(match3, 7.9, 8.3);
             var grade4 = new Grade(match4, 8.5);
             var grade5 = new Grade(match5, 8.1);
             var grade6 = new Grade(match6, 8.4);

--- a/src/main/java/com/jamex/refereestaffer/model/converter/GradeConverter.java
+++ b/src/main/java/com/jamex/refereestaffer/model/converter/GradeConverter.java
@@ -18,7 +18,7 @@ public class GradeConverter implements BaseConverter<Grade, GradeDto> {
 
     @Override
     public GradeDto convertFromEntity(Grade entity) {
-        return new GradeDto(entity.getId(), entity.getValue());
+        return new GradeDto(entity.getId(), entity.getValue(), entity.getSecondValue());
     }
 
     @Override
@@ -30,6 +30,6 @@ public class GradeConverter implements BaseConverter<Grade, GradeDto> {
                     .map(Grade::getMatch)
                     .orElseThrow(() -> new GradeNotFoundException(dto.getId()));
         }
-        return new Grade(dto.getId(), dto.getValue(), match);
+        return new Grade(dto.getId(), dto.getValue(), dto.getSecondValue(), match);
     }
 }

--- a/src/main/java/com/jamex/refereestaffer/model/dto/GradeDto.java
+++ b/src/main/java/com/jamex/refereestaffer/model/dto/GradeDto.java
@@ -10,9 +10,13 @@ public class GradeDto {
     @NotNull
     private final Double value;
 
-    public GradeDto(Long id, Double value) {
+    // Second component of a split grade (e.g. 7.9/8.3); null for a plain grade.
+    private final Double secondValue;
+
+    public GradeDto(Long id, Double value, Double secondValue) {
         this.id = id;
         this.value = value;
+        this.secondValue = secondValue;
     }
 
     public Long getId() {
@@ -23,6 +27,10 @@ public class GradeDto {
         return value;
     }
 
+    public Double getSecondValue() {
+        return secondValue;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -30,6 +38,7 @@ public class GradeDto {
     public static class Builder {
         private Long id;
         private Double value;
+        private Double secondValue;
 
         public Builder id(Long id) {
             this.id = id;
@@ -41,8 +50,13 @@ public class GradeDto {
             return this;
         }
 
+        public Builder secondValue(Double secondValue) {
+            this.secondValue = secondValue;
+            return this;
+        }
+
         public GradeDto build() {
-            return new GradeDto(id, value);
+            return new GradeDto(id, value, secondValue);
         }
     }
 }

--- a/src/main/java/com/jamex/refereestaffer/model/entity/Grade.java
+++ b/src/main/java/com/jamex/refereestaffer/model/entity/Grade.java
@@ -19,6 +19,10 @@ public class Grade {
     @Column(nullable = false)
     private Double value;
 
+    // Second component of a "split" grade (e.g. 7.9/8.3). Null for a plain single grade.
+    @Column
+    private Double secondValue;
+
     @JsonIgnore
     @OneToOne(targetEntity = Match.class)
     private Match match;
@@ -26,9 +30,10 @@ public class Grade {
     public Grade() {
     }
 
-    public Grade(Long id, Double value, Match match) {
+    public Grade(Long id, Double value, Double secondValue, Match match) {
         this.id = id;
         this.value = value;
+        this.secondValue = secondValue;
         this.match = match;
     }
 
@@ -37,12 +42,33 @@ public class Grade {
         this.value = value;
     }
 
+    public Grade(Match match, double value, Double secondValue) {
+        this.match = match;
+        this.value = value;
+        this.secondValue = secondValue;
+    }
+
     public Long getId() {
         return id;
     }
 
     public Double getValue() {
         return value;
+    }
+
+    public Double getSecondValue() {
+        return secondValue;
+    }
+
+    /**
+     * The grade that counts towards referee statistics: the arithmetic mean of both
+     * components for a split grade (7.9/8.3 -> 8.1), or the single value otherwise.
+     */
+    public Double getEffectiveValue() {
+        if (value == null) {
+            return null;
+        }
+        return secondValue != null ? (value + secondValue) / 2 : value;
     }
 
     public Match getMatch() {
@@ -55,7 +81,7 @@ public class Grade {
 
     @Override
     public String toString() {
-        return "Grade(id=" + id + ", value=" + value + ")";
+        return "Grade(id=" + id + ", value=" + value + ", secondValue=" + secondValue + ")";
     }
 
     public static Builder builder() {
@@ -65,6 +91,7 @@ public class Grade {
     public static class Builder {
         private Long id;
         private Double value;
+        private Double secondValue;
         private Match match;
 
         public Builder id(Long id) {
@@ -77,13 +104,18 @@ public class Grade {
             return this;
         }
 
+        public Builder secondValue(Double secondValue) {
+            this.secondValue = secondValue;
+            return this;
+        }
+
         public Builder match(Match match) {
             this.match = match;
             return this;
         }
 
         public Grade build() {
-            return new Grade(id, value, match);
+            return new Grade(id, value, secondValue, match);
         }
     }
 }

--- a/src/main/java/com/jamex/refereestaffer/service/ImporterService.java
+++ b/src/main/java/com/jamex/refereestaffer/service/ImporterService.java
@@ -111,8 +111,7 @@ public class ImporterService {
             matchRepository.save(match);
 
             if (line.length == 8 && queue <= numberOfQueuesToImport) {
-                var value = Double.parseDouble(line[7]);
-                var grade = new Grade(match, value);
+                var grade = parseGrade(match, line[7]);
                 gradeRepository.save(grade);
             }
         }
@@ -120,6 +119,18 @@ public class ImporterService {
         var matches = matchRepository.findAll();
         log.info(CREATED + grades.size() + " grades");
         log.info(CREATED + matches.size() + " matches");
+    }
+
+    // The grade column holds either a plain grade ("8.3") or a split grade ("7.9/8.3") —
+    // an observer grade broken into two components; referee stats use their mean.
+    private Grade parseGrade(Match match, String rawGrade) {
+        var parts = rawGrade.split("/");
+        if (parts.length > 2) {
+            throw new NumberFormatException("Invalid grade format: " + rawGrade);
+        }
+        var value = Double.parseDouble(parts[0]);
+        var secondValue = parts.length == 2 ? Double.parseDouble(parts[1]) : null;
+        return new Grade(match, value, secondValue);
     }
 
     private void createReferees(List<String> lines) {

--- a/src/main/java/com/jamex/refereestaffer/service/ImporterService.java
+++ b/src/main/java/com/jamex/refereestaffer/service/ImporterService.java
@@ -124,7 +124,9 @@ public class ImporterService {
     // The grade column holds either a plain grade ("8.3") or a split grade ("7.9/8.3") —
     // an observer grade broken into two components; referee stats use their mean.
     private Grade parseGrade(Match match, String rawGrade) {
-        var parts = rawGrade.split("/");
+        // limit -1 keeps trailing empty strings, so a malformed "8.3/" fails
+        // on Double.parseDouble("") instead of silently passing as a plain grade
+        var parts = rawGrade.split("/", -1);
         if (parts.length > 2) {
             throw new NumberFormatException("Invalid grade format: " + rawGrade);
         }

--- a/src/main/java/com/jamex/refereestaffer/service/RefereeService.java
+++ b/src/main/java/com/jamex/refereestaffer/service/RefereeService.java
@@ -123,7 +123,7 @@ public class RefereeService {
             return DEFAULT_GRADE;
         }
         var refereeGrades = matchesWithGrade.stream()
-                .map(Grade::getValue)
+                .map(Grade::getEffectiveValue)
                 .reduce(0.0, Double::sum);
         return refereeGrades / matchesWithGrade.size();
     }

--- a/src/main/webapp/src/app/component/grade-list/grade-list.component.html
+++ b/src/main/webapp/src/app/component/grade-list/grade-list.component.html
@@ -45,8 +45,11 @@
           <td class="num right">{{ row.match.queue }}</td>
           <td class="num right">
             <div class="grade-cell">
+              @if (isSplit(row.grade)) {
+                <span class="mono muted grade-cell__split">{{ row.grade.value.toFixed(1) }}/{{ row.grade.secondValue!.toFixed(1) }}</span>
+              }
               <app-meter [value]="gradeAsMeter(row.grade)" [max]="100" [kind]="gradeKind(row.grade)"></app-meter>
-              <span class="mono grade-cell__value">{{ row.grade.value.toFixed(1) }}</span>
+              <span class="mono grade-cell__value">{{ effectiveValue(row.grade).toFixed(1) }}</span>
             </div>
           </td>
           <td class="col-actions">

--- a/src/main/webapp/src/app/component/grade-list/grade-list.component.scss
+++ b/src/main/webapp/src/app/component/grade-list/grade-list.component.scss
@@ -31,6 +31,11 @@
   text-align: right;
 }
 
+/* Split-grade breakdown ("7.9/8.3") shown next to the effective mean. */
+.grade-cell__split {
+  font-size: 11px;
+}
+
 .row-actions {
   display: flex;
   gap: 4px;

--- a/src/main/webapp/src/app/component/grade-list/grade-list.component.ts
+++ b/src/main/webapp/src/app/component/grade-list/grade-list.component.ts
@@ -4,7 +4,7 @@ import {forkJoin} from 'rxjs';
 import {Match} from '../../model/match';
 import {Referee} from '../../model/referee';
 import {Team} from '../../model/team';
-import {Grade} from '../../model/grade';
+import {Grade, effectiveGradeValue, isSplitGrade} from '../../model/grade';
 import {MatchService} from '../../service/match.service';
 import {RefereeService} from '../../service/referee.service';
 import {TeamService} from '../../service/team.service';
@@ -89,12 +89,20 @@ export class GradeListComponent implements OnInit {
     return team.short ?? team.name?.slice(0, 3).toUpperCase() ?? '';
   }
 
+  effectiveValue(grade: Grade): number {
+    return effectiveGradeValue(grade);
+  }
+
+  isSplit(grade: Grade): boolean {
+    return isSplitGrade(grade);
+  }
+
   gradeAsMeter(grade: Grade): number {
-    return grade.value * 10;
+    return effectiveGradeValue(grade) * 10;
   }
 
   gradeKind(grade: Grade): 'default' | 'warn' {
-    return grade.value >= 7 ? 'default' : 'warn';
+    return effectiveGradeValue(grade) >= 7 ? 'default' : 'warn';
   }
 
   editGrade(row: GradeRow, event: Event): void {

--- a/src/main/webapp/src/app/component/match-form/match-form.component.html
+++ b/src/main/webapp/src/app/component/match-form/match-form.component.html
@@ -80,8 +80,15 @@
       </div>
       <div class="field-block">
         <label class="lbl" for="grade">Ref grade<span class="opt">optional</span></label>
-        <input class="input num" type="number" id="grade" name="grade" min="0" step="0.1" placeholder="0.0"
-               [(ngModel)]="grade.value">
+        <div class="grade-split">
+          <input class="input num" type="number" id="grade" name="grade" min="0" step="0.1" placeholder="0.0"
+                 [(ngModel)]="grade.value" (ngModelChange)="onGradeValueChange($event)">
+          <span class="grade-split__sep mono">/</span>
+          <input class="input num" type="number" id="secondGrade" name="secondGrade" min="0" step="0.1" placeholder="—"
+                 title="Second component of a split grade (e.g. 7.9/8.3)"
+                 [(ngModel)]="grade.secondValue" [disabled]="gradeValueMissing">
+        </div>
+        <span class="hint">Split grade? Put the second component after the slash.</span>
       </div>
     </div>
   </form>

--- a/src/main/webapp/src/app/component/match-form/match-form.component.spec.ts
+++ b/src/main/webapp/src/app/component/match-form/match-form.component.spec.ts
@@ -141,6 +141,20 @@ describe('MatchFormComponent', () => {
       expect(emitted).toEqual([saved]);
     });
 
+    it('saves a split grade with both components', () => {
+      const component = createComponent(null).componentInstance;
+      const saved = makeMatch({id: 42});
+      matchService.save.and.returnValue(of(saved));
+      gradeService.save.and.returnValue(of({id: 6, value: 7.9, secondValue: 8.3}));
+
+      component.grade.value = 7.9;
+      component.grade.secondValue = 8.3;
+      component.onSubmit(validForm);
+
+      expect(gradeService.save).toHaveBeenCalledWith(saved, component.grade);
+      expect(component.grade.secondValue).toBe(8.3);
+    });
+
     it('saves an entered grade against the newly created match before emitting', () => {
       const component = createComponent(null).componentInstance;
       const saved = makeMatch({id: 42});
@@ -242,6 +256,28 @@ describe('MatchFormComponent', () => {
 
       expect(matchService.update).not.toHaveBeenCalled();
       expect(emitted).toEqual([]);
+    });
+  });
+
+  describe('split grade input', () => {
+    it('drops the second component when the first one is cleared', () => {
+      const component = createComponent(null).componentInstance;
+      component.grade.value = 7.9;
+      component.grade.secondValue = 8.3;
+
+      component.onGradeValueChange(null);
+
+      expect(component.grade.secondValue).toBeUndefined();
+    });
+
+    it('keeps the second component while the first one has a value', () => {
+      const component = createComponent(null).componentInstance;
+      component.grade.value = 7.9;
+      component.grade.secondValue = 8.3;
+
+      component.onGradeValueChange(8.0);
+
+      expect(component.grade.secondValue).toBe(8.3);
     });
   });
 });

--- a/src/main/webapp/src/app/component/match-form/match-form.component.ts
+++ b/src/main/webapp/src/app/component/match-form/match-form.component.ts
@@ -84,6 +84,17 @@ export class MatchFormComponent implements OnInit {
       });
   }
 
+  /** Gates the second grade input — a split grade needs its first component first. */
+  get gradeValueMissing(): boolean {
+    return this.grade.value == null;
+  }
+
+  onGradeValueChange(value: number | null): void {
+    // A split grade can't consist of the second component alone — clearing the first
+    // part drops the second one too (the input is disabled in that state anyway).
+    if (value == null) this.grade.secondValue = undefined;
+  }
+
   private isGradeRemoved() {
     return this.grade.id;
   }

--- a/src/main/webapp/src/app/component/match-list/match-list.component.ts
+++ b/src/main/webapp/src/app/component/match-list/match-list.component.ts
@@ -4,7 +4,7 @@ import {forkJoin} from 'rxjs';
 import {Match} from '../../model/match';
 import {Team} from '../../model/team';
 import {Referee} from '../../model/referee';
-import {Grade} from '../../model/grade';
+import {Grade, effectiveGradeValue} from '../../model/grade';
 import {ModalData} from '../../model/modalData';
 import {MatchService} from '../../service/match.service';
 import {TeamService} from '../../service/team.service';
@@ -208,7 +208,7 @@ export class MatchListComponent implements OnInit {
 
   /** Grade values are 1..10 — scale to 0..100 for the Meter atom (max=100). */
   gradeAsMeter(grade: Grade | undefined): number {
-    return (grade?.value ?? 0) * 10;
+    return (grade ? effectiveGradeValue(grade) : 0) * 10;
   }
 }
 

--- a/src/main/webapp/src/app/component/referee-profile/referee-profile.component.html
+++ b/src/main/webapp/src/app/component/referee-profile/referee-profile.component.html
@@ -122,7 +122,7 @@
               @if (getGrade(match.gradeId); as g) {
                 <div class="grade-cell">
                   <app-meter [value]="gradeAsMeter(g)" [max]="100"></app-meter>
-                  <span class="mono grade-cell__value">{{ g.value.toFixed(1) }}</span>
+                  <span class="mono grade-cell__value">{{ displayGrade(g) }}</span>
                 </div>
               } @else {
                 <span class="muted">—</span>

--- a/src/main/webapp/src/app/component/referee-profile/referee-profile.component.ts
+++ b/src/main/webapp/src/app/component/referee-profile/referee-profile.component.ts
@@ -4,7 +4,7 @@ import {forkJoin} from 'rxjs';
 import {Match} from '../../model/match';
 import {Referee} from '../../model/referee';
 import {Team} from '../../model/team';
-import {Grade} from '../../model/grade';
+import {Grade, effectiveGradeValue} from '../../model/grade';
 import {RefereeService} from '../../service/referee.service';
 import {MatchService} from '../../service/match.service';
 import {TeamService} from '../../service/team.service';
@@ -88,8 +88,9 @@ export class RefereeProfileComponent implements OnInit {
     const fromServer = this.referee()?.averageGrade;
     if (typeof fromServer === 'number') return fromServer;
     const grades = this.matches()
-      .map(m => m.gradeId != null ? this.gradesById().get(m.gradeId)?.value : undefined)
-      .filter((v): v is number => typeof v === 'number');
+      .map(m => m.gradeId != null ? this.gradesById().get(m.gradeId) : undefined)
+      .filter((g): g is Grade => g != null)
+      .map(effectiveGradeValue);
     if (grades.length === 0) return null;
     return grades.reduce((s, g) => s + g, 0) / grades.length;
   });
@@ -177,7 +178,11 @@ export class RefereeProfileComponent implements OnInit {
   }
 
   gradeAsMeter(grade: Grade | undefined): number {
-    return (grade?.value ?? 0) * 10;
+    return (grade ? effectiveGradeValue(grade) : 0) * 10;
+  }
+
+  displayGrade(grade: Grade): string {
+    return effectiveGradeValue(grade).toFixed(1);
   }
 
   formatGrade(value: number | null): string {

--- a/src/main/webapp/src/app/model/grade.spec.ts
+++ b/src/main/webapp/src/app/model/grade.spec.ts
@@ -1,0 +1,24 @@
+import {Grade, effectiveGradeValue, isSplitGrade} from './grade';
+
+describe('Grade model helpers', () => {
+  it('returns the single value for a plain grade', () => {
+    const grade: Grade = {id: 1, value: 8.3};
+
+    expect(effectiveGradeValue(grade)).toBe(8.3);
+    expect(isSplitGrade(grade)).toBeFalse();
+  });
+
+  it('returns the arithmetic mean of both components for a split grade', () => {
+    const grade: Grade = {id: 1, value: 7.9, secondValue: 8.3};
+
+    expect(effectiveGradeValue(grade)).toBeCloseTo(8.1, 10);
+    expect(isSplitGrade(grade)).toBeTrue();
+  });
+
+  it('treats an explicit null second component as a plain grade', () => {
+    const grade: Grade = {id: 1, value: 7.9, secondValue: null};
+
+    expect(effectiveGradeValue(grade)).toBe(7.9);
+    expect(isSplitGrade(grade)).toBeFalse();
+  });
+});

--- a/src/main/webapp/src/app/model/grade.ts
+++ b/src/main/webapp/src/app/model/grade.ts
@@ -1,4 +1,19 @@
 export interface Grade {
   id: number;
   value: number;
+  /** Second component of a split grade (e.g. 7.9/8.3); absent for a plain grade. */
+  secondValue?: number | null;
+}
+
+/**
+ * The grade that counts towards referee statistics: the arithmetic mean of both
+ * components of a split grade (7.9/8.3 -> 8.1), or the single value otherwise.
+ * Mirrors Grade.getEffectiveValue() on the backend.
+ */
+export function effectiveGradeValue(grade: Grade): number {
+  return grade.secondValue != null ? (grade.value + grade.secondValue) / 2 : grade.value;
+}
+
+export function isSplitGrade(grade: Grade): boolean {
+  return grade.secondValue != null;
 }

--- a/src/main/webapp/src/styles.scss
+++ b/src/main/webapp/src/styles.scss
@@ -405,6 +405,10 @@ label.field .req { color: var(--danger); margin-left: 2px; }
   box-shadow: 0 0 0 3px var(--danger-tint);
 }
 textarea.input { height: auto; min-height: 64px; padding: 8px 10px; line-height: 1.5; resize: vertical; }
+/* Two-part input for split grades, entered as "first / second" (match form). */
+.grade-split { display: flex; align-items: center; gap: 6px; }
+.grade-split .input { min-width: 0; }
+.grade-split__sep { color: var(--ink-3); }
 
 .form-section-label {
   font-size: 11px; text-transform: uppercase; letter-spacing: 0.07em;

--- a/src/test/groovy/com/jamex/refereestaffer/controller/GradeControllerSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/controller/GradeControllerSpec.groovy
@@ -74,6 +74,25 @@ class GradeControllerSpec extends Specification {
         json.value == 8.5
     }
 
+    def "should return split grade as JSON"() {
+        given:
+        def gradeId = 77l
+        def grade = [] as Grade
+        def gradeDto = GradeDto.builder().id(gradeId).value(7.9d).secondValue(8.3d).build()
+
+        when:
+        def response = mockMvc.perform(get("/api/grades/$gradeId")).andReturn().response
+
+        then:
+        1 * gradeRepository.findById(gradeId) >> Optional.of(grade)
+        1 * gradeConverter.convertFromEntity(grade) >> gradeDto
+        response.status == 200
+        def json = new JsonSlurper().parseText(response.contentAsString)
+        json.id == gradeId
+        json.value == 7.9
+        json.secondValue == 8.3
+    }
+
     def "should respond 404 with problem detail when grade has not been found"() {
         given:
         def gradeId = 77l
@@ -97,6 +116,18 @@ class GradeControllerSpec extends Specification {
 
         then:
         1 * gradeService.addGrade({ GradeDto dto -> dto.value == 8.5d }, 2396l)
+        response.status == 200
+    }
+
+    def "should add split grade for match"() {
+        when:
+        def response = mockMvc.perform(post("/api/grades/2396")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content('{"value": 7.9, "secondValue": 8.3}'))
+                .andReturn().response
+
+        then:
+        1 * gradeService.addGrade({ GradeDto dto -> dto.value == 7.9d && dto.secondValue == 8.3d }, 2396l)
         response.status == 200
     }
 

--- a/src/test/groovy/com/jamex/refereestaffer/model/converter/GradeConverterSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/model/converter/GradeConverterSpec.groovy
@@ -29,6 +29,20 @@ class GradeConverterSpec extends Specification {
         then:
         result.id == entity.id
         result.value == entity.value
+        result.secondValue == null
+    }
+
+    def "should convert split grade from entity to dto"() {
+        given:
+        def entity = [getId: { 23l }, getValue: { 7.9 as double }, getSecondValue: { 8.3 as double }] as Grade
+
+        when:
+        def result = gradeConverter.convertFromEntity(entity)
+
+        then:
+        result.id == entity.id
+        result.value == entity.value
+        result.secondValue == entity.secondValue
     }
 
     def "should throw GradeNotFoundException when Grade has not been found"() {
@@ -63,6 +77,26 @@ class GradeConverterSpec extends Specification {
         result.id == gradeDto.id
         result.value == gradeDto.value
         result.match == grade.match
+    }
+
+    def "should convert split grade from dto to entity"() {
+        given:
+        def match = [] as Match
+        def grade = [getMatch: { match } ] as Grade
+        def gradeDto = GradeDto.builder()
+                .id(23l)
+                .value(7.9 as double)
+                .secondValue(8.3 as double)
+                .build()
+
+        when:
+        def result = gradeConverter.convertFromDto(gradeDto)
+
+        then:
+        1 * gradeRepository.findById(gradeDto.id) >> Optional.of(grade)
+        result.value == gradeDto.value
+        result.secondValue == gradeDto.secondValue
+        result.effectiveValue == (gradeDto.value + gradeDto.secondValue) / 2
     }
 
     def "should convert from dto to Grade entity when id is null"() {

--- a/src/test/groovy/com/jamex/refereestaffer/model/entity/GradeSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/model/entity/GradeSpec.groovy
@@ -1,0 +1,35 @@
+package com.jamex.refereestaffer.model.entity
+
+import spock.lang.Specification
+
+class GradeSpec extends Specification {
+
+    def "should return single value as effective value for a plain grade"() {
+        given:
+        def grade = Grade.builder()
+                .value(8.3d)
+                .build()
+
+        expect:
+        grade.effectiveValue == 8.3d
+    }
+
+    def "should return arithmetic mean of both components as effective value for a split grade"() {
+        given:
+        def grade = Grade.builder()
+                .value(7.9d)
+                .secondValue(8.3d)
+                .build()
+
+        expect:
+        grade.effectiveValue == (7.9d + 8.3d) / 2
+    }
+
+    def "should return null effective value when grade has no value"() {
+        given:
+        def grade = Grade.builder().build()
+
+        expect:
+        grade.effectiveValue == null
+    }
+}

--- a/src/test/groovy/com/jamex/refereestaffer/service/ImporterServiceSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/service/ImporterServiceSpec.groovy
@@ -99,9 +99,9 @@ class ImporterServiceSpec extends Specification {
         1 * teamRepository.findAll() >> []
     }
 
-    def "should throw ImportException when grade has more than two components"() {
+    def "should throw ImportException when grade is malformed"() {
         given:
-        def csv = "queue;home;away;date;referee;homeScore;awayScore;grade\n1;Team1;Team2;01.01.2025 12:00;John Smith;1;0;7.9/8.3/8.5"
+        def csv = "queue;home;away;date;referee;homeScore;awayScore;grade\n1;Team1;Team2;01.01.2025 12:00;John Smith;1;0;$rawGrade"
         MultipartFile multipartFile = new MockMultipartFile("file", "bad-grade.csv", "text/csv", csv.getBytes())
 
         when:
@@ -114,6 +114,9 @@ class ImporterServiceSpec extends Specification {
         1 * refereeRepository.findByFirstNameAndLastName("John", "Smith") >> Optional.of(new Referee())
         1 * matchRepository.save(_)
         thrown(ImportException)
+
+        where:
+        rawGrade << ["7.9/8.3/8.5", "8.3/", "/8.3"]
     }
 
     def "should throw ImportException when CSV row has missing columns"() {

--- a/src/test/groovy/com/jamex/refereestaffer/service/ImporterServiceSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/service/ImporterServiceSpec.groovy
@@ -1,5 +1,6 @@
 package com.jamex.refereestaffer.service
 
+import com.jamex.refereestaffer.model.entity.Grade
 import com.jamex.refereestaffer.model.entity.Referee
 import com.jamex.refereestaffer.model.entity.Team
 import com.jamex.refereestaffer.model.exception.ImportException
@@ -73,6 +74,46 @@ class ImporterServiceSpec extends Specification {
         0 * refereeRepository.findByFirstNameAndLastName(_, _)
         0 * matchRepository.save(_)
         0 * gradeRepository.save(_)
+    }
+
+    def "should import split grade from CSV"() {
+        given:
+        def csv = "queue;home;away;date;referee;homeScore;awayScore;grade\n1;Team1;Team2;01.01.2025 12:00;John Smith;1;0;7.9/8.3"
+        MultipartFile multipartFile = new MockMultipartFile("file", "split-grade.csv", "text/csv", csv.getBytes())
+
+        when:
+        importerService.importData(multipartFile, 30 as short)
+
+        then:
+        1 * teamRepository.saveAll(_)
+        1 * refereeRepository.saveAll(_)
+        2 * teamRepository.findByName(_) >> Optional.of(new Team())
+        1 * refereeRepository.findByFirstNameAndLastName("John", "Smith") >> Optional.of(new Referee())
+        1 * matchRepository.save(_)
+        1 * gradeRepository.save({ Grade grade ->
+            grade.value == 7.9d && grade.secondValue == 8.3d && grade.effectiveValue == (7.9d + 8.3d) / 2
+        })
+        2 * matchRepository.findAll() >> []
+        1 * refereeRepository.findAll() >> []
+        2 * gradeRepository.findAll() >> []
+        1 * teamRepository.findAll() >> []
+    }
+
+    def "should throw ImportException when grade has more than two components"() {
+        given:
+        def csv = "queue;home;away;date;referee;homeScore;awayScore;grade\n1;Team1;Team2;01.01.2025 12:00;John Smith;1;0;7.9/8.3/8.5"
+        MultipartFile multipartFile = new MockMultipartFile("file", "bad-grade.csv", "text/csv", csv.getBytes())
+
+        when:
+        importerService.importData(multipartFile, 30 as short)
+
+        then:
+        1 * teamRepository.saveAll(_)
+        1 * refereeRepository.saveAll(_)
+        2 * teamRepository.findByName(_) >> Optional.of(new Team())
+        1 * refereeRepository.findByFirstNameAndLastName("John", "Smith") >> Optional.of(new Referee())
+        1 * matchRepository.save(_)
+        thrown(ImportException)
     }
 
     def "should throw ImportException when CSV row has missing columns"() {

--- a/src/test/groovy/com/jamex/refereestaffer/service/RefereeServiceSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/service/RefereeServiceSpec.groovy
@@ -111,6 +111,40 @@ class RefereeServiceSpec extends Specification {
         referees.get(1).numberOfMatchesInRound == (short) 0
     }
 
+    def "should average split grades using their arithmetic mean"() {
+        given:
+        def referee = Referee.builder()
+                .firstName("John")
+                .lastName("Smith")
+                .build()
+        def team1 = Team.builder().name("team1").build()
+        def team2 = Team.builder().name("team2").build()
+        def splitGradeMatch = Match.builder()
+                .home(team1)
+                .away(team2)
+                .grade(Grade.builder()
+                        .value(7.9d)
+                        .secondValue(8.3d)
+                        .build())
+                .referee(referee)
+                .build()
+        def plainGradeMatch = Match.builder()
+                .home(team2)
+                .away(team1)
+                .grade(Grade.builder()
+                        .value(8.5d)
+                        .build())
+                .referee(referee)
+                .build()
+
+        when:
+        refereeService.calculateStats([referee])
+
+        then:
+        1 * matchRepository.findAllByRefereeIn([referee]) >> [splitGradeMatch, plainGradeMatch]
+        referee.averageGrade == ((7.9d + 8.3d) / 2 + 8.5d) / 2
+    }
+
     def "should count home and away wins skipping draws and unfinished matches"() {
         given:
         def referee = Referee.builder()


### PR DESCRIPTION
## Ticket

[RS-7 — Co z łamanym ocenami?](https://referee-staffer.youtrack.cloud/issue/RS-7)

In Polish football, an observer grade can be a *split grade* ("łamana ocena") — two components such as `7.9/8.3` instead of a single number. The system only stored one `value` per grade, so split grades could not be recorded at all. The ticket settles the design: store both components and use their arithmetic mean (`7.9/8.3 → 8.1`) wherever a single number is needed.

## Plan

1. **Backend model**: keep the existing `value` column as the first (and for plain grades, only) component and add a nullable `secondValue` column to `Grade`; expose `getEffectiveValue()` returning the mean when the second component is present. Keeping the existing column name avoids a data-losing rename under `ddl-auto: update`.
2. **API**: carry `secondValue` through `GradeDto` and `GradeConverter` (additive, backward-compatible JSON change).
3. **Statistics**: `RefereeService.countAverageGrade` averages effective values, so split grades feed referee potential correctly.
4. **Importer**: accept `7.9/8.3` in the CSV grade column; malformed grades (more than two components) fail the import with the existing 400 path.
5. **Frontend**: mirror the model (`secondValue?` + `effectiveGradeValue()` helper), add an optional second grade input to the match form, and switch every display/aggregation site (grade list, match list, referee profile) to the effective value, showing the `7.9/8.3` breakdown where relevant.
6. **Tests**: Spock for the entity, converter, referee average, importer, and controller JSON contract; Karma for the model helper and match-form behaviour.

## Changes

**Backend**

- `Grade` entity: new nullable `secondValue` column, `getEffectiveValue()` (mean for split grades, plain value otherwise, `null`-safe), extended builder/constructors/`toString`.
- `GradeDto` + `GradeConverter`: `secondValue` passes through both conversion directions; it stays optional (`@NotNull` only on `value`).
- `RefereeService.countAverageGrade`: uses `Grade::getEffectiveValue` instead of `Grade::getValue`.
- `ImporterService`: new `parseGrade` splits the grade column on `/`; one component → plain grade, two → split grade, more → `NumberFormatException`, which the existing catch wraps into `ImportException` (HTTP 400).
- Dev-profile seed: one demo grade is now a split grade so the feature is visible out of the box.

**Frontend**

- `model/grade.ts`: `secondValue?: number | null`, plus `effectiveGradeValue()` / `isSplitGrade()` helpers mirroring the backend semantics.
- Match form: the grade field is now a two-part input (`first / second`). The second input is disabled until the first component is filled and is cleared automatically when the first one is cleared, so a second-component-only grade can't be submitted. The save/update/delete decision tree in `onSubmit` is untouched.
- Grade list: meter, warn threshold, and the printed value use the effective value; split grades additionally show the `7.9/8.3` breakdown next to the mean.
- Match list + referee profile: meters, the match-history grade cell, and the client-side average fallback use the effective value.

**Design decisions**

- The mean is computed on read (`getEffectiveValue`) rather than stored, so there is a single source of truth and no denormalized column to keep in sync.
- `value` keeps its name and `NOT NULL` constraint; `secondValue` is additive — existing rows and API clients are unaffected, and H2 `ddl-auto: update` adds the column without touching data.

## Testing

- **Backend** (`mvn -DskipFrontend=true test`, JDK 25): 140 tests green. New/extended specs: `GradeSpec` (effective-value semantics incl. null value), `GradeConverterSpec` (split round-trip both directions), `RefereeServiceSpec` (average mixes split and plain grades via the mean), `ImporterServiceSpec` (imports `7.9/8.3`; `7.9/8.3/8.5` → `ImportException`), `GradeControllerSpec` (JSON contract for GET and POST with `secondValue`).
- **Frontend** (`npm ci`, `npm run lint`, `npm test` headless, `npm run build`): lint clean, 143 tests green, production build succeeds. New specs: `grade.spec.ts` (helper semantics incl. explicit `null`), match-form split-grade submit and second-component clearing.

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01UadVCzrSLUPCJsQrkGPQrj)_