### PR TITLE
RS-15: Wire up the match list Filter button with real status filters

### DIFF
--- a/src/main/webapp/src/app/component/match-list/match-list.component.html
+++ b/src/main/webapp/src/app/component/match-list/match-list.component.html
@@ -6,10 +6,12 @@
   <div class="page-head__actions">
     <input type="text" class="input" placeholder="Search team…"
            [value]="searchTerm()" (input)="setSearch($any($event.target).value)">
-    <!-- Filter button is a placeholder — advanced filters (referee assignment,
-         date range, etc.) are a future addition. -->
-    <button type="button" class="btn" disabled title="Filters coming soon">
+    <button type="button" class="btn" [class.btn--filter-active]="activeFilterCount() > 0"
+            (click)="toggleFilters()" title="Filter matches">
       <app-icon name="filter" [size]="12"></app-icon>Filter
+      @if (activeFilterCount() > 0) {
+        <span class="filter-count">{{ activeFilterCount() }}</span>
+      }
     </button>
     <button type="button" class="btn btn--primary" (click)="addMatch()">
       <app-icon name="plus" [size]="12"></app-icon>New match
@@ -17,9 +19,34 @@
   </div>
 </div>
 
+@if (filtersOpen()) {
+  <div class="filter-bar">
+    <div class="filter-bar__group">
+      <span class="filter-bar__label">Result</span>
+      <app-seg [options]="resultOptions" [value]="resultFilter()"
+               (valueChange)="resultFilter.set($event)"></app-seg>
+    </div>
+    <div class="filter-bar__group">
+      <span class="filter-bar__label">Referee</span>
+      <app-seg [options]="refereeOptions" [value]="refereeFilter()"
+               (valueChange)="refereeFilter.set($event)"></app-seg>
+    </div>
+    @if (activeFilterCount() > 0) {
+      <button type="button" class="btn btn--ghost btn--sm" (click)="clearFilters()">
+        <app-icon name="x" [size]="12"></app-icon>Clear
+      </button>
+    }
+  </div>
+}
+
 <div class="panel">
   <div class="panel__head">
     <div class="seg">
+      @if (availableQueues().length > 0) {
+        <button type="button" [class.active]="selectedQueue() === null" (click)="selectQueue(null)">
+          All queues
+        </button>
+      }
       @for (q of availableQueues(); track q) {
         <button type="button" [class.active]="q === selectedQueue()" (click)="selectQueue(q)">
           Queue {{ q }}
@@ -86,6 +113,8 @@
           <td colspan="6" class="empty-row">
             @if (searchTerm()) {
               <span class="muted">No matches match "{{ searchTerm() }}".</span>
+            } @else if (activeFilterCount() > 0) {
+              <span class="muted">No matches match the current filters.</span>
             } @else {
               <span class="muted">No matches in this queue.</span>
             }

--- a/src/main/webapp/src/app/component/match-list/match-list.component.html
+++ b/src/main/webapp/src/app/component/match-list/match-list.component.html
@@ -7,6 +7,7 @@
     <input type="text" class="input" placeholder="Search team…"
            [value]="searchTerm()" (input)="setSearch($any($event.target).value)">
     <button type="button" class="btn" [class.btn--filter-active]="activeFilterCount() > 0"
+            [attr.aria-expanded]="filtersOpen()"
             (click)="toggleFilters()" title="Filter matches">
       <app-icon name="filter" [size]="12"></app-icon>Filter
       @if (activeFilterCount() > 0) {
@@ -115,6 +116,8 @@
               <span class="muted">No matches match "{{ searchTerm() }}".</span>
             } @else if (activeFilterCount() > 0) {
               <span class="muted">No matches match the current filters.</span>
+            } @else if (selectedQueue() === null) {
+              <span class="muted">No matches yet.</span>
             } @else {
               <span class="muted">No matches in this queue.</span>
             }

--- a/src/main/webapp/src/app/component/match-list/match-list.component.scss
+++ b/src/main/webapp/src/app/component/match-list/match-list.component.scss
@@ -8,6 +8,46 @@
   width: 220px;
 }
 
+// Filter button gets the accent treatment while any filter is active, so the state
+// stays visible even when the bar itself is collapsed.
+.btn--filter-active {
+  border-color: var(--accent);
+  color: var(--accent-ink);
+}
+
+.filter-count {
+  min-width: 16px; height: 16px; padding: 0 4px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 8px;
+  background: var(--accent);
+  color: white;
+  font-size: 10px; font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-bottom: 16px;
+  padding: 10px 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--r);
+  background: var(--panel);
+}
+
+.filter-bar__group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.filter-bar__label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--ink-3);
+}
+
 .match-row {
   cursor: pointer;
 }

--- a/src/main/webapp/src/app/component/match-list/match-list.component.spec.ts
+++ b/src/main/webapp/src/app/component/match-list/match-list.component.spec.ts
@@ -130,6 +130,70 @@ describe('MatchListComponent', () => {
     expect(component.visibleMatches().map(m => m.id)).toEqual([13]);
   });
 
+  it('filters by result and referee assignment across all queues', async () => {
+    const component = (await create()).componentInstance;
+    component.selectQueue(null);
+
+    component.resultFilter.set('played');
+    expect(component.visibleMatches().map(m => m.id)).toEqual([11]);
+
+    component.resultFilter.set('unplayed');
+    expect(component.visibleMatches().map(m => m.id)).toEqual([12, 13]);
+
+    component.resultFilter.set('all');
+    component.refereeFilter.set('assigned');
+    expect(component.visibleMatches().map(m => m.id)).toEqual([11]);
+
+    component.refereeFilter.set('unassigned');
+    expect(component.visibleMatches().map(m => m.id)).toEqual([12, 13]);
+  });
+
+  it('combines status filters with the queue and the team search', async () => {
+    const component = (await create()).componentInstance;
+
+    component.selectQueue(2);
+    component.refereeFilter.set('unassigned');
+    component.setSearch('gamma');
+    expect(component.visibleMatches().map(m => m.id)).toEqual([12, 13]);
+
+    component.resultFilter.set('played');
+    expect(component.visibleMatches()).toEqual([]);
+  });
+
+  it('treats a half-recorded score as not played', async () => {
+    matchService.findAll.and.returnValue(of([makeMatch(31, {homeScore: 1})]));
+
+    const component = (await create()).componentInstance;
+    component.resultFilter.set('unplayed');
+
+    expect(component.visibleMatches().map(m => m.id)).toEqual([31]);
+  });
+
+  it('counts active filters and clears them in one go', async () => {
+    const component = (await create()).componentInstance;
+    expect(component.activeFilterCount()).toBe(0);
+
+    component.resultFilter.set('played');
+    component.refereeFilter.set('assigned');
+    expect(component.activeFilterCount()).toBe(2);
+
+    component.clearFilters();
+    expect(component.activeFilterCount()).toBe(0);
+    expect(component.resultFilter()).toBe('all');
+    expect(component.refereeFilter()).toBe('all');
+  });
+
+  it('toggles the filter bar', async () => {
+    const component = (await create()).componentInstance;
+    expect(component.filtersOpen()).toBeFalse();
+
+    component.toggleFilters();
+    expect(component.filtersOpen()).toBeTrue();
+
+    component.toggleFilters();
+    expect(component.filtersOpen()).toBeFalse();
+  });
+
   it('renders the score only when both halves are present', async () => {
     const component = (await create()).componentInstance;
 

--- a/src/main/webapp/src/app/component/match-list/match-list.component.spec.ts
+++ b/src/main/webapp/src/app/component/match-list/match-list.component.spec.ts
@@ -130,6 +130,16 @@ describe('MatchListComponent', () => {
     expect(component.visibleMatches().map(m => m.id)).toEqual([13]);
   });
 
+  it('keeps an explicit "All queues" choice across the reload after a drawer save', async () => {
+    const component = (await create()).componentInstance;
+    expect(component.selectedQueue()).toBe(2);
+
+    component.selectQueue(null);
+    component.onSaved();
+
+    expect(component.selectedQueue()).toBeNull();
+  });
+
   it('filters by result and referee assignment across all queues', async () => {
     const component = (await create()).componentInstance;
     component.selectQueue(null);

--- a/src/main/webapp/src/app/component/match-list/match-list.component.ts
+++ b/src/main/webapp/src/app/component/match-list/match-list.component.ts
@@ -15,10 +15,15 @@ import {TeamPillComponent} from '../common/team-pill/team-pill.component';
 import {RefAvatarComponent} from '../common/ref-avatar/ref-avatar.component';
 import {MeterComponent} from '../common/meter/meter.component';
 import {ConfirmDialogComponent} from '../common/confirm-dialog/confirm-dialog.component';
+import {SegComponent, SegOption} from '../common/seg/seg.component';
 import {MatchFormComponent} from '../match-form/match-form.component';
 
+export type ResultFilter = 'all' | 'played' | 'unplayed';
+export type RefereeFilter = 'all' | 'assigned' | 'unassigned';
+
 /**
- * Match list — browse fixtures by queue, search by team name, edit / delete inline.
+ * Match list — browse fixtures by queue, search by team name, filter by result /
+ * referee assignment, edit / delete inline.
  *
  * Data fetch is a single forkJoin so all four dependencies (matches, teams, referees,
  * grades) land together — replaces the previous nested subscribe chain.
@@ -29,7 +34,7 @@ import {MatchFormComponent} from '../match-form/match-form.component';
   styleUrl: './match-list.component.scss',
   imports: [
     IconComponent, TeamPillComponent, RefAvatarComponent, MeterComponent, ConfirmDialogComponent,
-    MatchFormComponent
+    SegComponent, MatchFormComponent
   ]
 })
 export class MatchListComponent implements OnInit {
@@ -47,6 +52,25 @@ export class MatchListComponent implements OnInit {
 
   readonly selectedQueue = signal<number | null>(null);
   readonly searchTerm = signal('');
+
+  /** Filter bar state — toggled by the "Filter" button in the page head. */
+  readonly filtersOpen = signal(false);
+  readonly resultFilter = signal<ResultFilter>('all');
+  readonly refereeFilter = signal<RefereeFilter>('all');
+
+  readonly resultOptions: SegOption<ResultFilter>[] = [
+    {value: 'all', label: 'All'},
+    {value: 'played', label: 'Played'},
+    {value: 'unplayed', label: 'Not played'}
+  ];
+  readonly refereeOptions: SegOption<RefereeFilter>[] = [
+    {value: 'all', label: 'All'},
+    {value: 'assigned', label: 'Assigned'},
+    {value: 'unassigned', label: 'Unassigned'}
+  ];
+
+  readonly activeFilterCount = computed(() =>
+    (this.resultFilter() === 'all' ? 0 : 1) + (this.refereeFilter() === 'all' ? 0 : 1));
 
   /** Add/edit drawer state — the list owns it (repo forms convention, see CLAUDE.md). */
   readonly formOpen = signal(false);
@@ -79,8 +103,12 @@ export class MatchListComponent implements OnInit {
   readonly visibleMatches = computed(() => {
     const queue = this.selectedQueue();
     const term = this.searchTerm().trim().toLowerCase();
+    const result = this.resultFilter();
+    const referee = this.refereeFilter();
     return this.matches()
       .filter(m => queue == null || m.queue === queue)
+      .filter(m => result === 'all' || (result === 'played') === isPlayed(m))
+      .filter(m => referee === 'all' || (referee === 'assigned') === (m.refereeId != null))
       .filter(m => {
         if (!term) return true;
         const home = this.getTeam(m.homeTeamId)?.name?.toLowerCase() ?? '';
@@ -132,12 +160,21 @@ export class MatchListComponent implements OnInit {
     });
   }
 
-  selectQueue(q: number): void {
+  selectQueue(q: number | null): void {
     this.selectedQueue.set(q);
   }
 
   setSearch(value: string): void {
     this.searchTerm.set(value);
+  }
+
+  toggleFilters(): void {
+    this.filtersOpen.update(open => !open);
+  }
+
+  clearFilters(): void {
+    this.resultFilter.set('all');
+    this.refereeFilter.set('all');
   }
 
   openDetail(match: Match): void {
@@ -210,6 +247,11 @@ export class MatchListComponent implements OnInit {
   gradeAsMeter(grade: Grade | undefined): number {
     return (grade?.value ?? 0) * 10;
   }
+}
+
+/** A match counts as played once both halves of the score are recorded. */
+function isPlayed(match: Match): boolean {
+  return match.homeScore != null && match.awayScore != null;
 }
 
 function unique<T>(arr: T[]): T[] {

--- a/src/main/webapp/src/app/component/match-list/match-list.component.ts
+++ b/src/main/webapp/src/app/component/match-list/match-list.component.ts
@@ -50,7 +50,11 @@ export class MatchListComponent implements OnInit {
   readonly refereesById = signal<Map<number, Referee>>(new Map());
   readonly gradesById = signal<Map<number, Grade>>(new Map());
 
-  readonly selectedQueue = signal<number | null>(null);
+  /**
+   * `undefined` = not initialized yet (load() will default to the latest queue),
+   * `null` = the user explicitly picked "All queues" — must survive a reload.
+   */
+  readonly selectedQueue = signal<number | null | undefined>(undefined);
   readonly searchTerm = signal('');
 
   /** Filter bar state — toggled by the "Filter" button in the page head. */
@@ -152,8 +156,9 @@ export class MatchListComponent implements OnInit {
         this.gradesById.set(toMap(grades));
 
         // Default to the latest queue with matches so the user lands on something.
+        // Only on first load — an explicit "All queues" choice (null) must stick.
         const queues = this.availableQueues();
-        if (queues.length > 0 && this.selectedQueue() == null) {
+        if (queues.length > 0 && this.selectedQueue() === undefined) {
           this.selectedQueue.set(queues[0]);
         }
       });

--- a/src/main/webapp/src/app/component/match-list/match-list.component.ts
+++ b/src/main/webapp/src/app/component/match-list/match-list.component.ts
@@ -107,8 +107,8 @@ export class MatchListComponent implements OnInit {
     const referee = this.refereeFilter();
     return this.matches()
       .filter(m => queue == null || m.queue === queue)
-      .filter(m => result === 'all' || (result === 'played') === isPlayed(m))
-      .filter(m => referee === 'all' || (referee === 'assigned') === (m.refereeId != null))
+      .filter(m => matchesResult(m, result))
+      .filter(m => matchesReferee(m, referee))
       .filter(m => {
         if (!term) return true;
         const home = this.getTeam(m.homeTeamId)?.name?.toLowerCase() ?? '';
@@ -252,6 +252,17 @@ export class MatchListComponent implements OnInit {
 /** A match counts as played once both halves of the score are recorded. */
 function isPlayed(match: Match): boolean {
   return match.homeScore != null && match.awayScore != null;
+}
+
+function matchesResult(match: Match, filter: ResultFilter): boolean {
+  if (filter === 'all') return true;
+  return filter === 'played' ? isPlayed(match) : !isPlayed(match);
+}
+
+function matchesReferee(match: Match, filter: RefereeFilter): boolean {
+  if (filter === 'all') return true;
+  const assigned = match.refereeId != null;
+  return filter === 'assigned' ? assigned : !assigned;
 }
 
 function unique<T>(arr: T[]): T[] {


### PR DESCRIPTION
## Ticket

[RS-15 — Filtrowanie w liście meczów](https://referee-staffer.youtrack.cloud/issue/RS-15)

The match list already gained team-name search and a queue segment during the 2026-06 redesign, but the "Filter" button in the page head remained a disabled placeholder that did nothing. The ticket asked to either wire up real filters (match status: played / not played, with / without assignment, queue range) or remove the button. This PR wires it up.

## Plan

1. Keep everything client-side — the list already holds all matches in a signal, so filtering is a pure `computed()` extension; no backend changes needed.
2. Make the "Filter" button toggle an **inline filter bar** rather than a popover. The repo deliberately has only two overlay primitives (`app-drawer`, `app-confirm-dialog`), so no third overlay is introduced.
3. Put two segmented controls (`app-seg` atom) in the bar:
   - **Result**: All / Played / Not played — a match counts as played once both score halves are recorded (same rule `scoreOrPlaceholder` already uses).
   - **Referee**: All / Assigned / Unassigned — keyed on `refereeId` presence, matching the "unassigned" label already shown in the table.
4. Surface active-filter state on the button itself (count badge + accent border) so it stays visible when the bar is collapsed, and add a one-click "Clear" action.
5. Add an "All queues" option to the queue segment — the minimal take on the ticket's "queue range", and status filters are far more useful when they can span the whole season. `selectedQueue === null` already meant "no queue filter" in `visibleMatches`, it just had no UI.
6. Cover the new logic with component specs and run lint + the full Karma suite headless.

## Changes

- `match-list.component.ts`
  - New signals `filtersOpen`, `resultFilter`, `refereeFilter` plus `activeFilterCount` computed and `toggleFilters()` / `clearFilters()` methods.
  - `visibleMatches` now also filters by result and referee assignment; the comparisons are written as `(result === 'played') === isPlayed(m)` so one predicate covers both directions of each filter.
  - `selectQueue` accepts `null` for the "All queues" segment option.
  - `ResultFilter` / `RefereeFilter` string-literal union types keep the seg options and signals in sync.
- `match-list.component.html`
  - Filter button enabled: toggles the bar, shows a count badge, gets an accent border while any filter is active.
  - New `.filter-bar` block with two labelled `app-seg` groups and a ghost "Clear" button (rendered only when something is active).
  - "All queues" button prepended to the queue segment (only when there are queues at all).
  - Empty-state message distinguishes "no matches match the current filters" from the search / plain-queue cases.
- `match-list.component.scss` — styles for the filter bar, label, count badge and active button state, all on existing design tokens (border over shadow, single accent, `tabular-nums` on the numeric badge).
- `match-list.component.spec.ts` — six new specs (see Testing).

Design decisions: filters intentionally stay when the bar is collapsed (the badge tells you they're on); the search-term empty state keeps priority over the filter empty state since a typed search is the more specific signal.

## Testing

- `npm run lint` — clean.
- `npm test` (Karma, ChromeHeadlessNoSandbox) — **142/142 SUCCESS**, including new specs for: result + referee filtering across all queues, combining status filters with queue selection and team search, the half-recorded-score edge case counting as not played, `activeFilterCount` + `clearFilters()`, and the filter-bar toggle.

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKaEzP6rbQJSwyABczR7Vt)_