### PR TITLE
RS-27: Serve the computed league table from the standings endpoint

### DIFF
--- a/src/main/java/com/jamex/refereestaffer/controller/TeamController.java
+++ b/src/main/java/com/jamex/refereestaffer/controller/TeamController.java
@@ -1,6 +1,7 @@
 package com.jamex.refereestaffer.controller;
 
 import com.jamex.refereestaffer.model.converter.TeamConverter;
+import com.jamex.refereestaffer.model.dto.StandingsDto;
 import com.jamex.refereestaffer.model.dto.TeamDto;
 import com.jamex.refereestaffer.model.exception.TeamNotFoundException;
 import com.jamex.refereestaffer.model.request.IDRequest;
@@ -81,10 +82,9 @@ public class TeamController {
     }
 
     @GetMapping("/standings")
-    public Collection<TeamDto> getStandings() {
+    public StandingsDto getStandings() {
         log.info("Calculating standings");
-        var teams = teamService.getStandings();
-        return teamConverter.convertFromEntities(teams);
+        return teamService.getStandings();
     }
 
     @DeleteMapping

--- a/src/main/java/com/jamex/refereestaffer/model/dto/StandingsDto.java
+++ b/src/main/java/com/jamex/refereestaffer/model/dto/StandingsDto.java
@@ -1,0 +1,38 @@
+package com.jamex.refereestaffer.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * The computed league table served by {@code GET /api/teams/standings}. Replaces the
+ * old {@code Collection<TeamDto>} response so the frontend no longer has to derive
+ * P/W/D/L/GF/GA client-side from the full match list.
+ *
+ * {@code afterQueue} is the highest queue with at least one finished match ("table
+ * after queue N" in the UI), or {@code null} before the season starts.
+ */
+public record StandingsDto(
+        Short afterQueue,
+        List<Row> rows
+) {
+    /**
+     * One table row. Carries the same team fields as {@link TeamDto} (so team pills
+     * render from a row directly) plus the season stats. `place` is 1-based table
+     * position — teams without a finished match sort to the bottom with zeroed stats.
+     */
+    public record Row(
+            Long id,
+            String name,
+            String city,
+            @JsonProperty("short") String shortCode,
+            short points,
+            short place,
+            short played,
+            short wins,
+            short draws,
+            short losses,
+            short goalsFor,
+            short goalsAgainst
+    ) {}
+}

--- a/src/main/java/com/jamex/refereestaffer/repository/TeamRepository.java
+++ b/src/main/java/com/jamex/refereestaffer/repository/TeamRepository.java
@@ -4,13 +4,10 @@ import com.jamex.refereestaffer.model.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface TeamRepository extends JpaRepository<Team, Long> {
-
-    List<Team> findAllByIdNotIn(List<Long> ids);
 
     Optional<Team> findByName(String name);
 }

--- a/src/main/java/com/jamex/refereestaffer/service/TeamService.java
+++ b/src/main/java/com/jamex/refereestaffer/service/TeamService.java
@@ -1,51 +1,110 @@
 package com.jamex.refereestaffer.service;
 
+import com.jamex.refereestaffer.model.dto.StandingsDto;
+import com.jamex.refereestaffer.model.entity.Match;
 import com.jamex.refereestaffer.model.entity.Team;
 import com.jamex.refereestaffer.repository.MatchRepository;
 import com.jamex.refereestaffer.repository.TeamRepository;
 import org.springframework.stereotype.Service;
 
-import java.util.Collection;
 import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.IntStream;
 
 @Service
 public class TeamService {
 
+    /** Shared zeroed stats for teams without a finished match — never mutated. */
+    private static final TeamStats NO_MATCHES = new TeamStats();
+
     private final TeamRepository teamRepository;
     private final MatchRepository matchRepository;
-    private final MatchService matchService;
 
-    public TeamService(TeamRepository teamRepository, MatchRepository matchRepository, MatchService matchService) {
+    public TeamService(TeamRepository teamRepository, MatchRepository matchRepository) {
         this.teamRepository = teamRepository;
         this.matchRepository = matchRepository;
-        this.matchService = matchService;
     }
 
-    public Collection<Team> getStandings() {
-        var matches = matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull();
-        matchService.calculatePointsForTeams(matches);
+    /**
+     * Builds the full league table from finished matches. Every team is included —
+     * teams without a finished match get zeroed stats and sort to the bottom. Points
+     * use the same weights as {@link MatchService#calculatePointsForTeams} (shared
+     * constants); ties break by goal difference, then goals scored, then name.
+     */
+    public StandingsDto getStandings() {
+        var finishedMatches = matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull();
 
-        var comparatorByPoints = Comparator.comparingInt(Team::getPoints).reversed();
-        var teams = matches.stream()
-                .flatMap(match -> Stream.of(match.getHome(), match.getAway()))
-                .distinct()
-                .sorted(comparatorByPoints)
-                .collect(Collectors.toList());
+        var statsByTeamId = new HashMap<Long, TeamStats>();
+        for (var match : finishedMatches) {
+            statsByTeamId.computeIfAbsent(match.getHome().getId(), id -> new TeamStats())
+                    .addResult(match.getHomeScore(), match.getAwayScore());
+            statsByTeamId.computeIfAbsent(match.getAway().getId(), id -> new TeamStats())
+                    .addResult(match.getAwayScore(), match.getHomeScore());
+        }
 
-        var teamIds = teams.stream()
-                .map(Team::getId)
+        var sortedTeams = teamRepository.findAll().stream()
+                .sorted(tableOrder(statsByTeamId))
                 .toList();
-        List<Team> teamsWithoutMatches;
-        // TODO probably this if could be removed
-        if (teamIds.isEmpty())
-            teamsWithoutMatches = teamRepository.findAll();
-        else
-            teamsWithoutMatches = teamRepository.findAllByIdNotIn(teamIds);
-        teams.addAll(teamsWithoutMatches);
+        var rows = IntStream.range(0, sortedTeams.size())
+                .mapToObj(i -> toRow(sortedTeams.get(i), (short) (i + 1), statsByTeamId))
+                .toList();
 
-        return teams;
+        var afterQueue = finishedMatches.stream()
+                .map(Match::getQueue)
+                .max(Short::compare)
+                .orElse(null);
+        return new StandingsDto(afterQueue, rows);
+    }
+
+    private static Comparator<Team> tableOrder(Map<Long, TeamStats> statsByTeamId) {
+        Comparator<Team> byPoints = Comparator.comparingInt(team -> statsOf(team, statsByTeamId).points());
+        Comparator<Team> byGoalDifference = Comparator.comparingInt(team -> statsOf(team, statsByTeamId).goalDifference());
+        Comparator<Team> byGoalsFor = Comparator.comparingInt(team -> statsOf(team, statsByTeamId).goalsFor);
+        return byPoints.reversed()
+                .thenComparing(byGoalDifference.reversed())
+                .thenComparing(byGoalsFor.reversed())
+                .thenComparing(Team::getName);
+    }
+
+    private static StandingsDto.Row toRow(Team team, short place, Map<Long, TeamStats> statsByTeamId) {
+        var stats = statsOf(team, statsByTeamId);
+        return new StandingsDto.Row(team.getId(), team.getName(), team.getCity(), team.getShortCode(),
+                (short) stats.points(), place, (short) stats.played, (short) stats.wins, (short) stats.draws,
+                (short) stats.losses, (short) stats.goalsFor, (short) stats.goalsAgainst);
+    }
+
+    private static TeamStats statsOf(Team team, Map<Long, TeamStats> statsByTeamId) {
+        return statsByTeamId.getOrDefault(team.getId(), NO_MATCHES);
+    }
+
+    /** Per-team accumulator. Ints internally — narrowed to short only when building the DTO row. */
+    private static final class TeamStats {
+        private int played;
+        private int wins;
+        private int draws;
+        private int losses;
+        private int goalsFor;
+        private int goalsAgainst;
+
+        void addResult(short scored, short conceded) {
+            played++;
+            goalsFor += scored;
+            goalsAgainst += conceded;
+            if (scored > conceded)
+                wins++;
+            else if (scored < conceded)
+                losses++;
+            else
+                draws++;
+        }
+
+        int points() {
+            return wins * MatchService.POINTS_FOR_WIN_MATCH + draws * MatchService.POINTS_FOR_DRAW_MATCH;
+        }
+
+        int goalDifference() {
+            return goalsFor - goalsAgainst;
+        }
     }
 }

--- a/src/main/webapp/src/app/component/dashboard/dashboard.component.spec.ts
+++ b/src/main/webapp/src/app/component/dashboard/dashboard.component.spec.ts
@@ -7,7 +7,7 @@ import {RefereeService} from '../../service/referee.service';
 import {TeamService} from '../../service/team.service';
 import {Match} from '../../model/match';
 import {Referee} from '../../model/referee';
-import {Team} from '../../model/team';
+import {Standing, Standings} from '../../model/standing';
 
 describe('DashboardComponent', () => {
   let matchService: jasmine.SpyObj<MatchService>;
@@ -15,9 +15,12 @@ describe('DashboardComponent', () => {
   let teamService: jasmine.SpyObj<TeamService>;
 
   // /api/teams/standings returns table order; 8 teams so both edge zones exist.
-  const standings: Team[] = Array.from({length: 8}, (_, i) => ({
-    id: i + 1, name: `Team ${i + 1}`, city: `City ${i + 1}`, points: 40 - i * 5
+  const rows: Standing[] = Array.from({length: 8}, (_, i) => ({
+    id: i + 1, name: `Team ${i + 1}`, city: `City ${i + 1}`, points: 40 - i * 5,
+    place: i + 1, played: 10, wins: 8 - i, draws: i, losses: 2,
+    goalsFor: 20 - i, goalsAgainst: 10 + i
   }));
+  const standings: Standings = {afterQueue: 10, rows};
 
   function makeMatch(id: number, overrides: Partial<Match> = {}): Match {
     return {
@@ -146,7 +149,7 @@ describe('DashboardComponent', () => {
   });
 
   it('suppresses the relegation zone in a league too small for both zones', () => {
-    teamService.getStandings.and.returnValue(of(standings.slice(0, 5)));
+    teamService.getStandings.and.returnValue(of({afterQueue: 10, rows: rows.slice(0, 5)}));
 
     const component = create().componentInstance;
 
@@ -157,8 +160,8 @@ describe('DashboardComponent', () => {
   it('scales points bars against the leader and flags three-digit difficulty', () => {
     const component = create().componentInstance;
 
-    expect(component.pointsBarPct(standings[0])).toBe(100);
-    expect(component.pointsBarPct(standings[4])).toBe(50);
+    expect(component.pointsBarPct(rows[0])).toBe(100);
+    expect(component.pointsBarPct(rows[4])).toBe(50);
     expect(component.difficultyKind(99)).toBe('default');
     expect(component.difficultyKind(100)).toBe('warn');
     expect(component.getTeam(3)?.name).toBe('Team 3');

--- a/src/main/webapp/src/app/component/dashboard/dashboard.component.ts
+++ b/src/main/webapp/src/app/component/dashboard/dashboard.component.ts
@@ -24,8 +24,8 @@ const NUMBER_OF_EDGE_TEAMS = 3;
  *    joined with team pills and the difficulty meter.
  *  - Top referees — sorted by `potential` desc (falls back to experience for
  *    un-enriched responses); the meter normalises against the top scorer.
- *  - Standings — only Pts + form bar (W/D/L/GF/GA need a season-stats endpoint that
- *    doesn't exist yet).
+ *  - Standings — only Pts + form bar by design; the full stats live on the
+ *    Standings screen (/api/teams/standings serves them).
  */
 @Component({
   selector: 'app-dashboard',
@@ -102,7 +102,7 @@ export class DashboardComponent implements OnInit {
     }).subscribe(({matches, referees, standings}) => {
       this.matches.set(matches);
       this.referees.set(referees);
-      this.standings.set(standings);
+      this.standings.set(standings.rows);
     });
   }
 

--- a/src/main/webapp/src/app/component/match-detail/match-detail.component.html
+++ b/src/main/webapp/src/app/component/match-detail/match-detail.component.html
@@ -145,10 +145,6 @@
             </div>
           </div>
         }
-        <div class="muted compare-todo">
-          Wins / draws / losses / goals require a per-team season-stats endpoint —
-          a planned backend addition.
-        </div>
       </div>
     </div>
   </div>

--- a/src/main/webapp/src/app/component/match-detail/match-detail.component.spec.ts
+++ b/src/main/webapp/src/app/component/match-detail/match-detail.component.spec.ts
@@ -6,7 +6,7 @@ import {MatchService} from '../../service/match.service';
 import {TeamService} from '../../service/team.service';
 import {RefereeService} from '../../service/referee.service';
 import {Match} from '../../model/match';
-import {Team} from '../../model/team';
+import {Standings} from '../../model/standing';
 import {Referee} from '../../model/referee';
 import {DifficultyBreakdown} from '../../model/difficultyBreakdown';
 
@@ -16,18 +16,24 @@ describe('MatchDetailComponent', () => {
   let refereeService: jasmine.SpyObj<RefereeService>;
   let navigateSpy: jasmine.Spy;
 
-  // Standings order defines place: index 0 = 1st. Teams 1 and 2 share a city so the
-  // local same-city fallback has something to detect.
-  const standings: Team[] = [
-    {id: 1, name: 'Alfa', city: 'Krakow', points: 40},
-    {id: 2, name: 'Beta', city: 'Krakow', points: 35},
-    {id: 3, name: 'Gamma', city: 'Gdansk', points: 30},
-    {id: 4, name: 'Delta', city: 'Poznan', points: 25},
-    {id: 5, name: 'Epsilon', city: 'Lodz', points: 20},
-    {id: 6, name: 'Zeta', city: 'Wroclaw', points: 15},
-    {id: 7, name: 'Eta', city: 'Radom', points: 10},
-    {id: 8, name: 'Theta', city: 'Opole', points: 5}
-  ];
+  // Backend rows carry `place`. Teams 1 and 2 share a city so the local same-city
+  // fallback has something to detect.
+  const standings: Standings = {
+    afterQueue: 10,
+    rows: [
+      {id: 1, name: 'Alfa', city: 'Krakow', points: 40},
+      {id: 2, name: 'Beta', city: 'Krakow', points: 35},
+      {id: 3, name: 'Gamma', city: 'Gdansk', points: 30},
+      {id: 4, name: 'Delta', city: 'Poznan', points: 25},
+      {id: 5, name: 'Epsilon', city: 'Lodz', points: 20},
+      {id: 6, name: 'Zeta', city: 'Wroclaw', points: 15},
+      {id: 7, name: 'Eta', city: 'Radom', points: 10},
+      {id: 8, name: 'Theta', city: 'Opole', points: 5}
+    ].map((team, i) => ({
+      ...team, place: i + 1, played: 10, wins: 8 - i, draws: i, losses: 2,
+      goalsFor: 20 - i, goalsAgainst: 10 + i
+    }))
+  };
 
   function makeReferee(id: number, overrides: Partial<Referee> = {}): Referee {
     return {
@@ -173,12 +179,17 @@ describe('MatchDetailComponent', () => {
     expect(component.assignedReferee()?.id).toBe(102);
   });
 
-  it('builds the compare rows from the joined teams', async () => {
+  it('builds the compare rows from the joined standings rows', async () => {
     const component = (await create(11)).componentInstance;
 
     expect(component.compareRows()).toEqual([
       {label: 'Position', home: '#1', away: '#2', bar: false},
-      {label: 'Points', home: 40, away: 35, bar: true}
+      {label: 'Points', home: 40, away: 35, bar: true},
+      {label: 'Wins', home: 8, away: 7, bar: true},
+      {label: 'Draws', home: 0, away: 1, bar: true},
+      {label: 'Losses', home: 2, away: 2, bar: true},
+      {label: 'Goals for', home: 20, away: 19, bar: true},
+      {label: 'Goals against', home: 10, away: 11, bar: true}
     ]);
   });
 

--- a/src/main/webapp/src/app/component/match-detail/match-detail.component.ts
+++ b/src/main/webapp/src/app/component/match-detail/match-detail.component.ts
@@ -2,7 +2,7 @@ import {Component, OnInit, computed, inject, signal, ChangeDetectionStrategy} fr
 import {ActivatedRoute, Router, RouterLink} from '@angular/router';
 import {forkJoin} from 'rxjs';
 import {Match} from '../../model/match';
-import {Team} from '../../model/team';
+import {Standing} from '../../model/standing';
 import {Referee} from '../../model/referee';
 import {DifficultyBreakdown} from '../../model/difficultyBreakdown';
 import {MatchService} from '../../service/match.service';
@@ -26,8 +26,8 @@ interface CompareRow {
  * Match detail — read-only deep dive on a single fixture.
  *
  * Difficulty parts load from /api/matches/:id/difficulty; candidate ranking uses the
- * enriched RefereeDto `potential`. Per-team W/D/L/GF/GA still wait on a season-stats
- * endpoint.
+ * enriched RefereeDto `potential`. Per-team season stats (place, W/D/L/GF/GA) come
+ * from the standings rows.
  */
 @Component({
   selector: 'app-match-detail',
@@ -45,10 +45,10 @@ export class MatchDetailComponent implements OnInit {
 
   readonly match = signal<Match | null>(null);
   readonly breakdown = signal<DifficultyBreakdown | null>(null);
-  readonly home = signal<Team | undefined>(undefined);
-  readonly away = signal<Team | undefined>(undefined);
-  /** Standings sorted by points desc — index lookup for `place`. */
-  readonly standings = signal<Team[]>([]);
+  readonly home = signal<Standing | undefined>(undefined);
+  readonly away = signal<Standing | undefined>(undefined);
+  /** Standings rows — carry the backend-computed `place` and season stats. */
+  readonly standings = signal<Standing[]>([]);
   readonly referees = signal<Referee[]>([]);
   readonly assignedReferee = signal<Referee | undefined>(undefined);
 
@@ -102,9 +102,11 @@ export class MatchDetailComponent implements OnInit {
     return [
       {label: 'Position', home: hp != null ? `#${hp}` : '—', away: ap != null ? `#${ap}` : '—', bar: false},
       {label: 'Points', home: h.points ?? 0, away: a.points ?? 0, bar: true},
-      // W / D / L / GF / GA need a backend stats endpoint that doesn't exist yet. For
-      // now they're omitted; placeholder note in the template tells the reader why the
-      // panel feels short.
+      {label: 'Wins', home: h.wins, away: a.wins, bar: true},
+      {label: 'Draws', home: h.draws, away: a.draws, bar: true},
+      {label: 'Losses', home: h.losses, away: a.losses, bar: true},
+      {label: 'Goals for', home: h.goalsFor, away: a.goalsFor, bar: true},
+      {label: 'Goals against', home: h.goalsAgainst, away: a.goalsAgainst, bar: true},
     ];
   });
 
@@ -134,10 +136,10 @@ export class MatchDetailComponent implements OnInit {
     }).subscribe(({match, breakdown, standings, referees}) => {
       this.match.set(match);
       this.breakdown.set(breakdown);
-      this.standings.set(standings);
+      this.standings.set(standings.rows);
       this.referees.set(referees);
-      this.home.set(standings.find(t => t.id === match.homeTeamId));
-      this.away.set(standings.find(t => t.id === match.awayTeamId));
+      this.home.set(standings.rows.find(t => t.id === match.homeTeamId));
+      this.away.set(standings.rows.find(t => t.id === match.awayTeamId));
       this.assignedReferee.set(referees.find(r => r.id === match.refereeId));
     });
   }
@@ -178,7 +180,6 @@ export class MatchDetailComponent implements OnInit {
 
   private placeOf(teamId: number | undefined): number | null {
     if (teamId == null) return null;
-    const idx = this.standings().findIndex(t => t.id === teamId);
-    return idx >= 0 ? idx + 1 : null;
+    return this.standings().find(t => t.id === teamId)?.place ?? null;
   }
 }

--- a/src/main/webapp/src/app/component/staffer/staffer.component.spec.ts
+++ b/src/main/webapp/src/app/component/staffer/staffer.component.spec.ts
@@ -8,7 +8,7 @@ import {RefereeService} from '../../service/referee.service';
 import {MatchService} from '../../service/match.service';
 import {UiSettingsService} from '../../service/ui-settings.service';
 import {Match} from '../../model/match';
-import {Team} from '../../model/team';
+import {Standings} from '../../model/standing';
 import {Referee} from '../../model/referee';
 import {DifficultyBreakdown} from '../../model/difficultyBreakdown';
 
@@ -21,18 +21,24 @@ describe('StafferComponent', () => {
   let matchService: jasmine.SpyObj<MatchService>;
   let explainerVisible: WritableSignal<boolean>;
 
-  // Standings order defines place: index 0 = 1st. 8 teams, NUMBER_OF_EDGE_TEAMS = 3,
-  // so top = both places <= 3, bottom = both places > 5. Teams 1 and 2 share a city.
-  const standings: Team[] = [
-    {id: 1, name: 'Alfa', city: 'Krakow', points: 40},
-    {id: 2, name: 'Beta', city: 'Krakow', points: 35},
-    {id: 3, name: 'Gamma', city: 'Gdansk', points: 30},
-    {id: 4, name: 'Delta', city: 'Poznan', points: 25},
-    {id: 5, name: 'Epsilon', city: 'Lodz', points: 20},
-    {id: 6, name: 'Zeta', city: 'Wroclaw', points: 15},
-    {id: 7, name: 'Eta', city: 'Radom', points: 10},
-    {id: 8, name: 'Theta', city: 'Opole', points: 5}
-  ];
+  // Backend rows carry `place`. 8 teams, NUMBER_OF_EDGE_TEAMS = 3, so top = both
+  // places <= 3, bottom = both places > 5. Teams 1 and 2 share a city.
+  const standings: Standings = {
+    afterQueue: 10,
+    rows: [
+      {id: 1, name: 'Alfa', city: 'Krakow', points: 40},
+      {id: 2, name: 'Beta', city: 'Krakow', points: 35},
+      {id: 3, name: 'Gamma', city: 'Gdansk', points: 30},
+      {id: 4, name: 'Delta', city: 'Poznan', points: 25},
+      {id: 5, name: 'Epsilon', city: 'Lodz', points: 20},
+      {id: 6, name: 'Zeta', city: 'Wroclaw', points: 15},
+      {id: 7, name: 'Eta', city: 'Radom', points: 10},
+      {id: 8, name: 'Theta', city: 'Opole', points: 5}
+    ].map((team, i) => ({
+      ...team, place: i + 1, played: 10, wins: 8 - i, draws: i, losses: 2,
+      goalsFor: 20 - i, goalsAgainst: 10 + i
+    }))
+  };
 
   function makeMatch(id: number, overrides: Partial<Match> = {}): Match {
     return {

--- a/src/main/webapp/src/app/component/staffer/staffer.component.ts
+++ b/src/main/webapp/src/app/component/staffer/staffer.component.ts
@@ -59,9 +59,9 @@ export class StafferComponent {
   readonly queue = signal(1);
   readonly matches = signal<Match[] | null>(null);
   readonly referees = signal<Referee[]>([]);
-  /** Map<teamId, Team> — populated from /api/teams/standings so `place` (== index+1) is meaningful. */
+  /** Map<teamId, Team> — populated from /api/teams/standings rows. */
   readonly teamsById = signal<Map<number, Team>>(new Map());
-  /** Map<teamId, place> — derived from standings sort order. */
+  /** Map<teamId, place> — the backend-computed table position. */
   readonly placeById = signal<Map<number, number>>(new Map());
   readonly totalTeams = signal(0);
 
@@ -121,17 +121,17 @@ export class StafferComponent {
       referees: this.refereeService.findRefereesAvailableForQueue(this.queue())
     }).subscribe({
       next: ({matches, standings, referees}) => {
-        // standings is sorted by points desc; index 0 = first place. Build place lookup
-        // so flag derivation (top/bottom) doesn't need re-sorting on every cell render.
+        // Build lookup maps so flag derivation (top/bottom) doesn't re-scan the table
+        // on every cell render; `place` comes straight from the backend row.
         const teamsMap = new Map<number, Team>();
         const placeMap = new Map<number, number>();
-        standings.forEach((t, i) => {
+        standings.rows.forEach(t => {
           teamsMap.set(t.id, t);
-          placeMap.set(t.id, i + 1);
+          placeMap.set(t.id, t.place);
         });
         this.teamsById.set(teamsMap);
         this.placeById.set(placeMap);
-        this.totalTeams.set(standings.length);
+        this.totalTeams.set(standings.rows.length);
         this.referees.set(referees);
         this.matches.set([...matches]);
         this.loading.set(false);

--- a/src/main/webapp/src/app/component/standings/standings.component.html
+++ b/src/main/webapp/src/app/component/standings/standings.component.html
@@ -3,7 +3,7 @@
     <h1>Standings</h1>
     <div class="page-head__sub">
       Ekstraklasa 2025/26
-      @if (latestPlayedQueue(); as q) {
+      @if (afterQueue(); as q) {
         · after queue {{ q }}
       }
     </div>
@@ -31,30 +31,30 @@
         </tr>
       </thead>
       <tbody>
-        @for (row of visibleRows(); track row.team.id) {
+        @for (row of visibleRows(); track row.standing.id) {
           <tr>
-            <td class="num pos-cell">{{ row.pos }}</td>
+            <td class="num pos-cell">{{ row.standing.place }}</td>
             <td>
               <span class="team-cell">
                 @if (row.zone) {
                   <span class="dot" [class.dot--accent]="row.zone === 'accent'"
                         [class.dot--danger]="row.zone === 'danger'"></span>
                 }
-                <app-team-pill [team]="row.team"></app-team-pill>
+                <app-team-pill [team]="row.standing"></app-team-pill>
               </span>
             </td>
-            <td class="city-cell">{{ row.team.city }}</td>
-            <td class="num right">{{ row.played }}</td>
-            <td class="num right">{{ row.wins }}</td>
-            <td class="num right">{{ row.draws }}</td>
-            <td class="num right">{{ row.losses }}</td>
-            <td class="num right">{{ row.goalsFor }}</td>
-            <td class="num right">{{ row.goalsAgainst }}</td>
+            <td class="city-cell">{{ row.standing.city }}</td>
+            <td class="num right">{{ row.standing.played }}</td>
+            <td class="num right">{{ row.standing.wins }}</td>
+            <td class="num right">{{ row.standing.draws }}</td>
+            <td class="num right">{{ row.standing.losses }}</td>
+            <td class="num right">{{ row.standing.goalsFor }}</td>
+            <td class="num right">{{ row.standing.goalsAgainst }}</td>
             <td class="num right"
                 [class.gd-positive]="goalDiff(row) > 0"
                 [class.gd-negative]="goalDiff(row) < 0"
                 [class.gd-zero]="goalDiff(row) === 0">{{ formatGoalDiff(row) }}</td>
-            <td class="num right pts-cell">{{ row.team.points ?? '—' }}</td>
+            <td class="num right pts-cell">{{ row.standing.points ?? '—' }}</td>
             <td>
               <div class="bar">
                 <i [style.width.%]="barPct(row)"

--- a/src/main/webapp/src/app/component/standings/standings.component.spec.ts
+++ b/src/main/webapp/src/app/component/standings/standings.component.spec.ts
@@ -2,39 +2,28 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {of} from 'rxjs';
 import {StandingsComponent} from './standings.component';
 import {TeamService} from '../../service/team.service';
-import {MatchService} from '../../service/match.service';
-import {Team} from '../../model/team';
-import {Match} from '../../model/match';
+import {Standing, Standings} from '../../model/standing';
 
 describe('StandingsComponent', () => {
   let teamService: jasmine.SpyObj<TeamService>;
-  let matchService: jasmine.SpyObj<MatchService>;
 
-  // /api/teams/standings returns table order; 8 teams so both edge zones exist.
-  const standings: Team[] = Array.from({length: 8}, (_, i) => ({
-    id: i + 1, name: `Team ${i + 1}`, city: `City ${i + 1}`, points: 40 - i * 5
+  // /api/teams/standings returns the computed table; 8 teams so both edge zones exist.
+  const rows: Standing[] = Array.from({length: 8}, (_, i) => ({
+    id: i + 1, name: `Team ${i + 1}`, city: `City ${i + 1}`, points: 40 - i * 5,
+    place: i + 1, played: 10, wins: 8 - i, draws: i, losses: 2,
+    goalsFor: 20 - i, goalsAgainst: 10 + i
   }));
 
-  const matches = [
-    // Team 1 beats Team 2 away: 1 has W 3:1, 2 has L.
-    {id: 11, queue: 1, homeTeamId: 2, awayTeamId: 1, homeScore: 1, awayScore: 3},
-    // Draw between 1 and 3.
-    {id: 12, queue: 2, homeTeamId: 1, awayTeamId: 3, homeScore: 2, awayScore: 2},
-    // Unplayed — must not count anywhere.
-    {id: 13, queue: 3, homeTeamId: 1, awayTeamId: 4}
-  ] as Match[];
+  const standings: Standings = {afterQueue: 10, rows};
 
   beforeEach(async () => {
     teamService = jasmine.createSpyObj('TeamService', ['getStandings']);
-    matchService = jasmine.createSpyObj('MatchService', ['findAll']);
     teamService.getStandings.and.returnValue(of(standings));
-    matchService.findAll.and.returnValue(of(matches));
 
     await TestBed.configureTestingModule({
       imports: [StandingsComponent],
       providers: [
-        {provide: TeamService, useValue: teamService},
-        {provide: MatchService, useValue: matchService}
+        {provide: TeamService, useValue: teamService}
       ]
     }).compileComponents();
   });
@@ -45,47 +34,42 @@ describe('StandingsComponent', () => {
     return fixture;
   }
 
-  it('derives W/D/L and goals from played matches only', () => {
-    const rows = create().componentInstance.rows();
-    const team1 = rows.find(r => r.team.id === 1)!;
-    const team2 = rows.find(r => r.team.id === 2)!;
-    const team4 = rows.find(r => r.team.id === 4)!;
+  it('renders the backend-computed stats without local derivation', () => {
+    const componentRows = create().componentInstance.rows();
+    const first = componentRows.find(r => r.standing.id === 1)!;
 
-    expect(team1).toEqual(jasmine.objectContaining(
-      {played: 2, wins: 1, draws: 1, losses: 0, goalsFor: 5, goalsAgainst: 3}));
-    expect(team2).toEqual(jasmine.objectContaining(
-      {played: 1, wins: 0, draws: 0, losses: 1, goalsFor: 1, goalsAgainst: 3}));
-    // Only fixture 13 references team 4 and it has no result.
-    expect(team4.played).toBe(0);
+    expect(componentRows.length).toBe(8);
+    expect(first.standing).toEqual(jasmine.objectContaining(
+      {place: 1, played: 10, wins: 8, draws: 0, losses: 2, goalsFor: 20, goalsAgainst: 10}));
   });
 
   it('marks the top three accent and the bottom three danger', () => {
-    const rows = create().componentInstance.rows();
+    const componentRows = create().componentInstance.rows();
 
-    expect(rows.filter(r => r.zone === 'accent').map(r => r.pos)).toEqual([1, 2, 3]);
-    expect(rows.filter(r => r.zone === 'danger').map(r => r.pos)).toEqual([6, 7, 8]);
-    expect(rows.filter(r => r.zone === null).map(r => r.pos)).toEqual([4, 5]);
+    expect(componentRows.filter(r => r.zone === 'accent').map(r => r.standing.place)).toEqual([1, 2, 3]);
+    expect(componentRows.filter(r => r.zone === 'danger').map(r => r.standing.place)).toEqual([6, 7, 8]);
+    expect(componentRows.filter(r => r.zone === null).map(r => r.standing.place)).toEqual([4, 5]);
   });
 
   it('suppresses the danger zone in a league too small for both zones', () => {
-    teamService.getStandings.and.returnValue(of(standings.slice(0, 5)));
+    teamService.getStandings.and.returnValue(of({afterQueue: 10, rows: rows.slice(0, 5)}));
 
-    const rows = create().componentInstance.rows();
+    const componentRows = create().componentInstance.rows();
 
-    expect(rows.filter(r => r.zone === 'accent').map(r => r.pos)).toEqual([1, 2, 3]);
-    expect(rows.some(r => r.zone === 'danger')).toBeFalse();
+    expect(componentRows.filter(r => r.zone === 'accent').map(r => r.standing.place)).toEqual([1, 2, 3]);
+    expect(componentRows.some(r => r.zone === 'danger')).toBeFalse();
   });
 
   it('formats the goal difference with an explicit sign', () => {
     const component = create().componentInstance;
-    const rows = component.rows();
-    const team1 = rows.find(r => r.team.id === 1)!; // GD +2
-    const team2 = rows.find(r => r.team.id === 2)!; // GD -2
-    const team3 = rows.find(r => r.team.id === 3)!; // GD 0
+    const componentRows = component.rows();
+    const positive = componentRows.find(r => r.standing.id === 1)!; // GD +10
+    const negative = componentRows.find(r => r.standing.id === 8)!; // GD -4
+    const zero = componentRows.find(r => r.standing.id === 6)!; // 15:15
 
-    expect(component.formatGoalDiff(team1)).toBe('+2');
-    expect(component.formatGoalDiff(team2)).toBe('-2');
-    expect(component.formatGoalDiff(team3)).toBe('0');
+    expect(component.formatGoalDiff(positive)).toBe('+10');
+    expect(component.formatGoalDiff(negative)).toBe('-4');
+    expect(component.formatGoalDiff(zero)).toBe('0');
   });
 
   it('filters the visible rows by zone segment', () => {
@@ -94,16 +78,22 @@ describe('StandingsComponent', () => {
     expect(component.visibleRows().length).toBe(8);
 
     component.filter.set('top');
-    expect(component.visibleRows().map(r => r.pos)).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(component.visibleRows().map(r => r.standing.place)).toEqual([1, 2, 3, 4, 5, 6]);
 
     component.filter.set('bottom');
-    expect(component.visibleRows().map(r => r.pos)).toEqual([6, 7, 8]);
+    expect(component.visibleRows().map(r => r.standing.place)).toEqual([6, 7, 8]);
   });
 
-  it('reports the latest queue with a played match, or null before the season starts', () => {
-    expect(create().componentInstance.latestPlayedQueue()).toBe(2);
+  it('shows the backend afterQueue in the subtitle, or nothing before the season starts', () => {
+    const fixture = create();
+    expect(fixture.componentInstance.afterQueue()).toBe(10);
+    expect((fixture.nativeElement as HTMLElement).querySelector('.page-head__sub')?.textContent)
+      .toContain('after queue 10');
 
-    matchService.findAll.and.returnValue(of([matches[2]]));
-    expect(create().componentInstance.latestPlayedQueue()).toBeNull();
+    teamService.getStandings.and.returnValue(of({afterQueue: null, rows: []}));
+    const emptyFixture = create();
+    expect(emptyFixture.componentInstance.afterQueue()).toBeNull();
+    expect((emptyFixture.nativeElement as HTMLElement).querySelector('.page-head__sub')?.textContent)
+      .not.toContain('after queue');
   });
 });

--- a/src/main/webapp/src/app/component/standings/standings.component.ts
+++ b/src/main/webapp/src/app/component/standings/standings.component.ts
@@ -1,9 +1,6 @@
 import {Component, OnInit, computed, inject, signal, ChangeDetectionStrategy} from '@angular/core';
-import {forkJoin} from 'rxjs';
-import {Team} from '../../model/team';
-import {Match} from '../../model/match';
+import {Standing} from '../../model/standing';
 import {TeamService} from '../../service/team.service';
-import {MatchService} from '../../service/match.service';
 import {TeamPillComponent} from '../common/team-pill/team-pill.component';
 import {SegComponent, SegOption} from '../common/seg/seg.component';
 
@@ -12,25 +9,18 @@ const NUMBER_OF_EDGE_TEAMS = 3;
 export type StandingsFilter = 'all' | 'top' | 'bottom';
 
 interface StandingRow {
-  team: Team;
-  pos: number;
+  standing: Standing;
   zone: 'accent' | 'danger' | null;
-  played: number;
-  wins: number;
-  draws: number;
-  losses: number;
-  goalsFor: number;
-  goalsAgainst: number;
 }
 
 /**
  * Standings — the full league table; standalone sibling of the Dashboard's standings
  * widget.
  *
- * Order and points come from /api/teams/standings (authoritative — points weighting is
- * configurable server-side); P/W/D/L/GF/GA are derived client-side from played matches,
- * the same way the team list derives "Played". Top 3 = accent zone, bottom 3 = danger,
- * matching the dashboard widget's NUMBER_OF_EDGE_TEAMS.
+ * The whole table (order, points, place, P/W/D/L/GF/GA and the "after queue N"
+ * subtitle) comes from /api/teams/standings — nothing is derived client-side anymore.
+ * Top 3 = accent zone, bottom 3 = danger, matching the dashboard widget's
+ * NUMBER_OF_EDGE_TEAMS.
  */
 @Component({
   selector: 'app-standings',
@@ -41,10 +31,9 @@ interface StandingRow {
 })
 export class StandingsComponent implements OnInit {
   private readonly teamService = inject(TeamService);
-  private readonly matchService = inject(MatchService);
 
-  readonly teams = signal<Team[]>([]);
-  readonly matches = signal<Match[]>([]);
+  readonly standings = signal<Standing[]>([]);
+  readonly afterQueue = signal<number | null>(null);
   readonly filter = signal<StandingsFilter>('all');
 
   readonly filterOptions: SegOption<StandingsFilter>[] = [
@@ -53,23 +42,13 @@ export class StandingsComponent implements OnInit {
     {value: 'bottom', label: `Bottom ${NUMBER_OF_EDGE_TEAMS}`}
   ];
 
-  /** Highest queue with at least one played match — "after queue N" in the subtitle. */
-  readonly latestPlayedQueue = computed<number | null>(() => {
-    const played = this.matches().filter(m => m.homeScore != null && m.awayScore != null);
-    if (played.length === 0) return null;
-    return Math.max(...played.map(m => m.queue));
-  });
-
   readonly rows = computed<StandingRow[]>(() => {
-    const stats = computeStats(this.matches());
-    const total = this.teams().length;
-    return this.teams().map((team, i) => {
-      const pos = i + 1;
-      const s = stats.get(team.id) ?? emptyStats();
-      const zone = pos <= NUMBER_OF_EDGE_TEAMS ? 'accent' as const
-        : (pos > total - NUMBER_OF_EDGE_TEAMS && total >= NUMBER_OF_EDGE_TEAMS * 2) ? 'danger' as const
+    const total = this.standings().length;
+    return this.standings().map(standing => {
+      const zone = standing.place <= NUMBER_OF_EDGE_TEAMS ? 'accent' as const
+        : (standing.place > total - NUMBER_OF_EDGE_TEAMS && total >= NUMBER_OF_EDGE_TEAMS * 2) ? 'danger' as const
         : null;
-      return {team, pos, zone, ...s};
+      return {standing, zone};
     });
   });
 
@@ -78,27 +57,24 @@ export class StandingsComponent implements OnInit {
     const total = this.rows().length;
     return this.rows().filter(row =>
       filter === 'all' ? true
-        : filter === 'top' ? row.pos <= NUMBER_OF_EDGE_TEAMS * 2
-        : row.pos > total - NUMBER_OF_EDGE_TEAMS);
+        : filter === 'top' ? row.standing.place <= NUMBER_OF_EDGE_TEAMS * 2
+        : row.standing.place > total - NUMBER_OF_EDGE_TEAMS);
   });
 
   readonly maxPoints = computed(() => {
-    const points = this.teams().map(t => t.points ?? 0);
+    const points = this.standings().map(s => s.points ?? 0);
     return Math.max(...points, 1);
   });
 
   ngOnInit(): void {
-    forkJoin({
-      standings: this.teamService.getStandings(),
-      matches: this.matchService.findAll()
-    }).subscribe(({standings, matches}) => {
-      this.teams.set(standings);
-      this.matches.set(matches);
+    this.teamService.getStandings().subscribe(standings => {
+      this.standings.set(standings.rows);
+      this.afterQueue.set(standings.afterQueue);
     });
   }
 
   goalDiff(row: StandingRow): number {
-    return row.goalsFor - row.goalsAgainst;
+    return row.standing.goalsFor - row.standing.goalsAgainst;
   }
 
   formatGoalDiff(row: StandingRow): string {
@@ -107,46 +83,6 @@ export class StandingsComponent implements OnInit {
   }
 
   barPct(row: StandingRow): number {
-    return Math.round(((row.team.points ?? 0) / this.maxPoints()) * 100);
+    return Math.round(((row.standing.points ?? 0) / this.maxPoints()) * 100);
   }
-}
-
-type Stats = Omit<StandingRow, 'team' | 'pos' | 'zone'>;
-
-function emptyStats(): Stats {
-  return {played: 0, wins: 0, draws: 0, losses: 0, goalsFor: 0, goalsAgainst: 0};
-}
-
-function computeStats(matches: Match[]): Map<number, Stats> {
-  const stats = new Map<number, Stats>();
-  const of = (id: number) => {
-    let s = stats.get(id);
-    if (!s) {
-      s = emptyStats();
-      stats.set(id, s);
-    }
-    return s;
-  };
-  for (const m of matches) {
-    if (m.homeScore == null || m.awayScore == null) continue;
-    const home = of(m.homeTeamId);
-    const away = of(m.awayTeamId);
-    home.played++;
-    away.played++;
-    home.goalsFor += m.homeScore;
-    home.goalsAgainst += m.awayScore;
-    away.goalsFor += m.awayScore;
-    away.goalsAgainst += m.homeScore;
-    if (m.homeScore > m.awayScore) {
-      home.wins++;
-      away.losses++;
-    } else if (m.homeScore < m.awayScore) {
-      away.wins++;
-      home.losses++;
-    } else {
-      home.draws++;
-      away.draws++;
-    }
-  }
-  return stats;
 }

--- a/src/main/webapp/src/app/component/team-list/team-list.component.html
+++ b/src/main/webapp/src/app/component/team-list/team-list.component.html
@@ -30,7 +30,7 @@
           <tr>
             <td><app-team-pill [team]="team"></app-team-pill></td>
             <td class="city-cell">{{ team.city }}</td>
-            <td class="num right">{{ played(team) }}</td>
+            <td class="num right">{{ team.played }}</td>
             <td class="num right points-cell">{{ team.points ?? '—' }}</td>
             <td><div class="bar"><i [style.width.%]="barPct(team)"></i></div></td>
             <td class="col-actions">

--- a/src/main/webapp/src/app/component/team-list/team-list.component.spec.ts
+++ b/src/main/webapp/src/app/component/team-list/team-list.component.spec.ts
@@ -3,35 +3,25 @@ import {ActivatedRoute, convertToParamMap, Router} from '@angular/router';
 import {of} from 'rxjs';
 import {TeamListComponent} from './team-list.component';
 import {TeamService} from '../../service/team.service';
-import {MatchService} from '../../service/match.service';
-import {Team} from '../../model/team';
-import {Match} from '../../model/match';
+import {Standing, Standings} from '../../model/standing';
 
 describe('TeamListComponent', () => {
   let teamService: jasmine.SpyObj<TeamService>;
-  let matchService: jasmine.SpyObj<MatchService>;
   let router: jasmine.SpyObj<Router>;
 
-  const standings: Team[] = [
-    {id: 1, name: 'Alfa', city: 'Krakow', points: 40},
-    {id: 2, name: 'Beta', city: 'Gdansk', points: 20},
-    {id: 3, name: 'Gamma', city: 'Krakow', points: 10}
+  const rows: Standing[] = [
+    {id: 1, name: 'Alfa', city: 'Krakow', points: 40, place: 1, played: 2, wins: 1, draws: 1, losses: 0, goalsFor: 2, goalsAgainst: 1},
+    {id: 2, name: 'Beta', city: 'Gdansk', points: 20, place: 2, played: 1, wins: 0, draws: 0, losses: 1, goalsFor: 1, goalsAgainst: 2},
+    {id: 3, name: 'Gamma', city: 'Krakow', points: 10, place: 3, played: 1, wins: 0, draws: 1, losses: 0, goalsFor: 0, goalsAgainst: 0}
   ];
 
-  const matches = [
-    {id: 11, queue: 1, homeTeamId: 1, awayTeamId: 2, homeScore: 2, awayScore: 1},
-    {id: 12, queue: 1, homeTeamId: 3, awayTeamId: 1, homeScore: 0, awayScore: 0},
-    // No result yet — must not count as played.
-    {id: 13, queue: 2, homeTeamId: 2, awayTeamId: 3}
-  ] as Match[];
+  const standings: Standings = {afterQueue: 2, rows};
 
   beforeEach(() => {
     teamService = jasmine.createSpyObj('TeamService', ['getStandings', 'findById', 'delete']);
-    matchService = jasmine.createSpyObj('MatchService', ['findAll']);
     router = jasmine.createSpyObj('Router', ['navigate']);
 
     teamService.getStandings.and.returnValue(of(standings));
-    matchService.findAll.and.returnValue(of(matches));
   });
 
   async function create(path = 'teams', id?: number): Promise<ComponentFixture<TeamListComponent>> {
@@ -39,7 +29,6 @@ describe('TeamListComponent', () => {
       imports: [TeamListComponent],
       providers: [
         {provide: TeamService, useValue: teamService},
-        {provide: MatchService, useValue: matchService},
         {provide: Router, useValue: router},
         {
           provide: ActivatedRoute,
@@ -52,15 +41,15 @@ describe('TeamListComponent', () => {
     return fixture;
   }
 
-  it('renders the standings order and derives played from finished matches only', async () => {
+  it('renders the standings order with the backend-computed played counter', async () => {
     const fixture = await create();
     const component = fixture.componentInstance;
 
     expect(component.teams().map(t => t.id)).toEqual([1, 2, 3]);
-    expect(component.played(standings[0])).toBe(2);
-    expect(component.played(standings[1])).toBe(1); // fixture 13 has no score
-    expect(component.played(standings[2])).toBe(1);
-    expect((fixture.nativeElement as HTMLElement).querySelectorAll('tbody tr').length).toBe(3);
+    expect(component.teams().map(t => t.played)).toEqual([2, 1, 1]);
+    const rendered = (fixture.nativeElement as HTMLElement).querySelectorAll('tbody tr');
+    expect(rendered.length).toBe(3);
+    expect(rendered[0].textContent).toContain('2');
   });
 
   it('filters by name or city', async () => {
@@ -76,15 +65,15 @@ describe('TeamListComponent', () => {
   it('scales the points bar to the leader', async () => {
     const component = (await create()).componentInstance;
 
-    expect(component.barPct(standings[0])).toBe(100);
-    expect(component.barPct(standings[1])).toBe(50);
+    expect(component.barPct(rows[0])).toBe(100);
+    expect(component.barPct(rows[1])).toBe(50);
   });
 
   it('deletes only after the confirm, naming the team in the guard', async () => {
     const component = (await create()).componentInstance;
     teamService.delete.and.returnValue(of(void 0));
 
-    component.askDelete(standings[1]);
+    component.askDelete(rows[1]);
     expect(component.deleteGuard().message).toContain('Beta');
     expect(teamService.delete).not.toHaveBeenCalled();
 
@@ -104,12 +93,12 @@ describe('TeamListComponent', () => {
     });
 
     it('fetches the team and opens the edit drawer for /addTeam/:id', async () => {
-      teamService.findById.and.returnValue(of(standings[0]));
+      teamService.findById.and.returnValue(of(rows[0]));
 
       const component = (await create('addTeam', 1)).componentInstance;
 
       expect(teamService.findById).toHaveBeenCalledWith(1);
-      expect(component.editingTeam()).toEqual(standings[0]);
+      expect(component.editingTeam()).toEqual(rows[0]);
       expect(component.formOpen()).toBeTrue();
     });
 
@@ -126,6 +115,7 @@ describe('TeamListComponent', () => {
     const component = (await create()).componentInstance;
     component.addTeam();
     teamService.getStandings.calls.reset();
+    teamService.getStandings.and.returnValue(of(standings));
 
     component.onSaved();
 

--- a/src/main/webapp/src/app/component/team-list/team-list.component.ts
+++ b/src/main/webapp/src/app/component/team-list/team-list.component.ts
@@ -1,11 +1,9 @@
 import {Component, OnInit, computed, inject, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
-import {forkJoin} from 'rxjs';
 import {Team} from '../../model/team';
-import {Match} from '../../model/match';
+import {Standing} from '../../model/standing';
 import {ModalData} from '../../model/modalData';
 import {TeamService} from '../../service/team.service';
-import {MatchService} from '../../service/match.service';
 import {IconComponent} from '../common/icon/icon.component';
 import {TeamPillComponent} from '../common/team-pill/team-pill.component';
 import {ConfirmDialogComponent} from '../common/confirm-dialog/confirm-dialog.component';
@@ -15,9 +13,8 @@ import {TeamFormComponent} from '../team-form/team-form.component';
  * Team list — searchable league directory sorted by points, with the add/edit drawer
  * and the delete confirm.
  *
- * "Played" is derived client-side from the match list (fixtures with both scores) —
- * the standings endpoint only carries points today; a backend `played` counter is a
- * tracked follow-up.
+ * Points and "Played" both come from /api/teams/standings — no client-side counting
+ * from the match list anymore.
  */
 @Component({
   selector: 'app-team-list',
@@ -30,11 +27,9 @@ export class TeamListComponent implements OnInit {
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
   private readonly teamService = inject(TeamService);
-  private readonly matchService = inject(MatchService);
 
-  /** Sorted by points desc — /api/teams/standings returns them in table order. */
-  readonly teams = signal<Team[]>([]);
-  readonly playedById = signal<Map<number, number>>(new Map());
+  /** Sorted by points desc — /api/teams/standings returns rows in table order. */
+  readonly teams = signal<Standing[]>([]);
   readonly searchTerm = signal('');
 
   /** Add/edit drawer state — the list owns it (repo forms convention, see CLAUDE.md). */
@@ -81,12 +76,8 @@ export class TeamListComponent implements OnInit {
   }
 
   private load(): void {
-    forkJoin({
-      standings: this.teamService.getStandings(),
-      matches: this.matchService.findAll()
-    }).subscribe(({standings, matches}) => {
-      this.teams.set(standings);
-      this.playedById.set(countPlayed(matches));
+    this.teamService.getStandings().subscribe(standings => {
+      this.teams.set(standings.rows);
     });
   }
 
@@ -94,11 +85,7 @@ export class TeamListComponent implements OnInit {
     this.searchTerm.set(value);
   }
 
-  played(team: Team): number {
-    return this.playedById().get(team.id) ?? 0;
-  }
-
-  barPct(team: Team): number {
+  barPct(team: Standing): number {
     return Math.round(((team.points ?? 0) / this.maxPoints()) * 100);
   }
 
@@ -138,15 +125,4 @@ export class TeamListComponent implements OnInit {
       this.deleteTarget.set(null);
     });
   }
-}
-
-/** Map<teamId, played> — a match counts once it has both scores. */
-function countPlayed(matches: Match[]): Map<number, number> {
-  const played = new Map<number, number>();
-  for (const m of matches) {
-    if (m.homeScore == null || m.awayScore == null) continue;
-    played.set(m.homeTeamId, (played.get(m.homeTeamId) ?? 0) + 1);
-    played.set(m.awayTeamId, (played.get(m.awayTeamId) ?? 0) + 1);
-  }
-  return played;
 }

--- a/src/main/webapp/src/app/model/standing.ts
+++ b/src/main/webapp/src/app/model/standing.ts
@@ -1,0 +1,22 @@
+import {Team} from './team';
+
+/**
+ * One row of the league table from GET /api/teams/standings. Extends Team so
+ * row objects drop into every Team-typed slot (team pills, lookups) directly.
+ */
+export interface Standing extends Team {
+  /** 1-based table position — teams without a finished match rank at the bottom. */
+  place: number;
+  played: number;
+  wins: number;
+  draws: number;
+  losses: number;
+  goalsFor: number;
+  goalsAgainst: number;
+}
+
+/** Full standings response; afterQueue is the latest queue with a played match. */
+export interface Standings {
+  afterQueue: number | null;
+  rows: Standing[];
+}

--- a/src/main/webapp/src/app/service/team.service.spec.ts
+++ b/src/main/webapp/src/app/service/team.service.spec.ts
@@ -6,6 +6,7 @@ import {TeamService} from './team.service';
 import {ToastService} from './toast.service';
 import {httpErrorInterceptor} from './http-error.interceptor';
 import {Team} from '../model/team';
+import {Standings} from '../model/standing';
 
 describe('TeamService', () => {
   const teamsUrl = '/api/teams';
@@ -93,14 +94,18 @@ describe('TeamService', () => {
   });
 
   it('getStandings GETs the standings endpoint', () => {
-    let result: Team[] | undefined;
-    service.getStandings().subscribe(teams => result = teams);
+    const standings: Standings = {
+      afterQueue: 12,
+      rows: [{...team, place: 1, played: 10, wins: 8, draws: 1, losses: 1, goalsFor: 20, goalsAgainst: 7}]
+    };
+    let result: Standings | undefined;
+    service.getStandings().subscribe(response => result = response);
 
     const req = httpTesting.expectOne(`${teamsUrl}/standings`);
     expect(req.request.method).toBe('GET');
-    req.flush([team]);
+    req.flush(standings);
 
-    expect(result).toEqual([team]);
+    expect(result).toEqual(standings);
   });
 
   it('delete DELETEs the team by id', () => {

--- a/src/main/webapp/src/app/service/team.service.ts
+++ b/src/main/webapp/src/app/service/team.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpHeaders } from "@angular/common/http";
 import {Observable} from "rxjs";
 import {Team} from "../model/team";
+import {Standings} from "../model/standing";
 import {environment} from "../../environments/environment";
 
 @Injectable({
@@ -38,8 +39,8 @@ export class TeamService {
     return this.http.put<Team>(this.teamsUrl, team)
   }
 
-  public getStandings(): Observable<Team[]> {
-    return this.http.get<Team[]>(`${this.teamsUrl}/standings`)
+  public getStandings(): Observable<Standings> {
+    return this.http.get<Standings>(`${this.teamsUrl}/standings`)
   }
 
   public delete(id: number): Observable<void> {

--- a/src/test/groovy/com/jamex/refereestaffer/controller/TeamControllerSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/controller/TeamControllerSpec.groovy
@@ -1,6 +1,7 @@
 package com.jamex.refereestaffer.controller
 
 import com.jamex.refereestaffer.model.converter.TeamConverter
+import com.jamex.refereestaffer.model.dto.StandingsDto
 import com.jamex.refereestaffer.model.dto.TeamDto
 import com.jamex.refereestaffer.model.entity.Team
 import com.jamex.refereestaffer.model.exception.TeamNotFoundException
@@ -191,20 +192,34 @@ class TeamControllerSpec extends Specification {
         json*.id == [23, 55]
     }
 
-    def "should return standings"() {
+    def "should return standings with computed stats and the wire-format short field"() {
         given:
-        def teams = [[] as Team]
-        def teamsDtos = [TeamDto.builder().points(30 as Short).build()]
+        def row = new StandingsDto.Row(65l, "Legia", "Warszawa", "LEG", 30 as short, 1 as short,
+                12 as short, 9 as short, 3 as short, 0 as short, 25 as short, 8 as short)
+        def standings = new StandingsDto(12 as Short, [row])
 
         when:
         def response = mockMvc.perform(get("/api/teams/standings")).andReturn().response
 
         then:
-        1 * teamService.getStandings() >> teams
-        1 * teamConverter.convertFromEntities(teams) >> teamsDtos
+        1 * teamService.getStandings() >> standings
+        0 * teamConverter._
         response.status == 200
         def json = new JsonSlurper().parseText(response.contentAsString)
-        json[0].points == 30
+        json.afterQueue == 12
+        json.rows.size() == 1
+        def firstRow = json.rows[0]
+        firstRow.id == 65
+        firstRow.name == "Legia"
+        firstRow.short == "LEG"
+        firstRow.points == 30
+        firstRow.place == 1
+        firstRow.played == 12
+        firstRow.wins == 9
+        firstRow.draws == 3
+        firstRow.losses == 0
+        firstRow.goalsFor == 25
+        firstRow.goalsAgainst == 8
     }
 
     def "should delete all teams"() {

--- a/src/test/groovy/com/jamex/refereestaffer/service/TeamServiceSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/service/TeamServiceSpec.groovy
@@ -7,6 +7,8 @@ import com.jamex.refereestaffer.repository.TeamRepository
 import spock.lang.Specification
 import spock.lang.Subject
 
+import java.time.LocalDateTime
+
 class TeamServiceSpec extends Specification {
 
     @Subject
@@ -14,43 +16,112 @@ class TeamServiceSpec extends Specification {
 
     TeamRepository teamRepository = Mock()
     MatchRepository matchRepository = Mock()
-    MatchService matchService = Mock()
 
     def setup() {
-        teamService = new TeamService(teamRepository, matchRepository, matchService)
+        teamService = new TeamService(teamRepository, matchRepository)
     }
 
-    def "should return standings (some matches has been played)"() {
+    def "should compute the full table from finished matches"() {
         given:
-        def team1 = [points: 6] as Team
-        def team2 = [points: 10] as Team
-        def team3 = [points: 3] as Team
-        def team4 = [points: 9] as Team
-        def team5 = [getId: 123] as Team
-        def matches = [[getHome: team1, getAway: team2] as Match, [getHome: team3, getAway: team4] as Match]
+        def alfa = Team.builder().id(1l).name("Alfa").build()
+        def beta = Team.builder().id(2l).name("Beta").build()
+        def gamma = Team.builder().id(3l).name("Gamma").build()
+        def delta = Team.builder().id(4l).name("Delta").build()
+        def matches = [finishedMatch(1, alfa, beta, 3, 1),
+                       finishedMatch(2, alfa, gamma, 2, 2)]
 
         when:
         def result = teamService.getStandings()
 
         then:
         1 * matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull() >> matches
-        1 * matchService.calculatePointsForTeams(matches)
-        1 * teamRepository.findAllByIdNotIn(_) >> [team5]
-        result.size() == 5
-        result == [team2, team4, team1, team3, team5]
+        1 * teamRepository.findAll() >> [alfa, beta, gamma, delta]
+
+        and: "afterQueue is the highest queue with a finished match"
+        result.afterQueue() == 2 as Short
+
+        and: "teams are ranked by points, zero-point teams tie-break by goal difference"
+        result.rows()*.name() == ["Alfa", "Gamma", "Delta", "Beta"]
+        result.rows()*.place() == (1..4).collect { it as Short }
+
+        and: "winner's stats add up across both matches"
+        with(result.rows()[0]) {
+            points() == 4 as Short
+            played() == 2 as Short
+            wins() == 1 as Short
+            draws() == 1 as Short
+            losses() == 0 as Short
+            goalsFor() == 5 as Short
+            goalsAgainst() == 3 as Short
+        }
+
+        and: "loser gets zero points and mirrored goals"
+        with(result.rows()[3]) {
+            points() == 0 as Short
+            played() == 1 as Short
+            losses() == 1 as Short
+            goalsFor() == 1 as Short
+            goalsAgainst() == 3 as Short
+        }
+
+        and: "a team without finished matches gets zeroed stats"
+        with(result.rows()[2]) {
+            name() == "Delta"
+            points() == 0 as Short
+            played() == 0 as Short
+        }
     }
 
-    def "should return standings (no matches have been played)"() {
+    def "should break point ties by goal difference, then goals scored, then name"() {
+        given: "four teams with one win each (3 points)"
+        def alfa = Team.builder().id(1l).name("Alfa").build()
+        def beta = Team.builder().id(2l).name("Beta").build()
+        def gamma = Team.builder().id(3l).name("Gamma").build()
+        def delta = Team.builder().id(4l).name("Delta").build()
+        def other = Team.builder().id(5l).name("Omega").build()
+        def matches = [finishedMatch(1, alfa, other, 1, 0), // GD +1, GF 1
+                       finishedMatch(1, beta, other, 3, 1), // GD +2, GF 3
+                       finishedMatch(1, gamma, other, 2, 1), // GD +1, GF 2
+                       finishedMatch(1, delta, other, 1, 0)] // GD +1, GF 1 — full tie with Alfa
+
+        when:
+        def result = teamService.getStandings()
+
+        then:
+        1 * matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull() >> matches
+        1 * teamRepository.findAll() >> [alfa, beta, gamma, delta, other]
+        result.rows()*.name() == ["Beta", "Gamma", "Alfa", "Delta", "Omega"]
+    }
+
+    def "should return an alphabetical zero-stats table before the season starts"() {
         given:
-        def teams = [[] as Team, [] as Team]
+        def wisla = Team.builder().id(1l).name("Wisla").build()
+        def legia = Team.builder().id(2l).name("Legia").build()
 
         when:
         def result = teamService.getStandings()
 
         then:
         1 * matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull() >> []
-        1 * matchService.calculatePointsForTeams([])
-        1 * teamRepository.findAll() >> teams
-        result == teams
+        1 * teamRepository.findAll() >> [wisla, legia]
+        result.afterQueue() == null
+        result.rows()*.name() == ["Legia", "Wisla"]
+        result.rows()*.place() == [1 as Short, 2 as Short]
+        result.rows().every { it.points() == 0 as Short && it.played() == 0 as Short }
+    }
+
+    def "should return an empty table when there are no teams"() {
+        when:
+        def result = teamService.getStandings()
+
+        then:
+        1 * matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull() >> []
+        1 * teamRepository.findAll() >> []
+        result.afterQueue() == null
+        result.rows().isEmpty()
+    }
+
+    private static Match finishedMatch(int queue, Team home, Team away, int homeScore, int awayScore) {
+        new Match(queue as short, home, away, LocalDateTime.now(), null, homeScore as Short, awayScore as Short)
     }
 }


### PR DESCRIPTION
# Ticket

[RS-27 — Standings liczone na backendzie (endpoint zamiast client-side)](https://referee-staffer.youtrack.cloud/issue/RS-27)

The Standings screen and the Team list both derived P/W/D/L/GF/GA (and "played") client-side from `GET /api/matches`, so each of those screens pulled the entire match list just to compute table stats. The ticket asks for a backend endpoint that returns the league table with computed statistics and `place`, and for the frontend to consume it instead of counting locally.

# Plan

1. **Backend — new response shape.** Add a `StandingsDto` record (following the `DifficultyBreakdownDto` record precedent): `afterQueue` (highest queue with a finished match, `null` before the season starts — feeds the "after queue N" subtitle) plus `rows`, where each row carries the `TeamDto` fields (`id`, `name`, `city`, `short`) and the computed season stats (`points`, `place`, `played`, `wins`, `draws`, `losses`, `goalsFor`, `goalsAgainst`).
2. **Backend — computation.** Rework `TeamService.getStandings()` to accumulate stats in one pass over finished matches, include every team (zeroed stats for teams without a finished match), sort by points desc → goal difference desc → goals scored desc → name, and assign `place = index + 1`. Reuse `MatchService`'s `POINTS_FOR_*` constants so the weights stay single-sourced. Drop the now-unneeded `MatchService` dependency and the `findAllByIdNotIn` two-query dance.
3. **Backend — controller.** `TeamController.getStandings()` returns the DTO directly (service already produces the read model; no converter step).
4. **Frontend — model & service.** New `Standing extends Team` + `Standings` wrapper interfaces; `TeamService.getStandings()` returns `Observable<Standings>`.
5. **Frontend — consumers.** `standings` and `team-list` stop fetching the match list; `dashboard`, `staffer` and `match-detail` switch to `.rows`, with `place` read from the row instead of being re-derived from the array index.
6. **Tests.** Rewrite `TeamServiceSpec` for the real computation (stats, tie-breakers, afterQueue, no-matches/no-teams edge cases), update the `TeamControllerSpec` standings feature for the new JSON shape, and update the Angular specs (standings, team-list, staffer) to the new mock shape.

Risks called out up front: the response shape of `/api/teams/standings` changes (all five consumers live in this repo and are updated in the same PR; there are no external consumers), and equal-points ordering changes from insertion order to explicit tie-breakers.

# Changes

**Backend**

- `StandingsDto` — new record with nested `Row`; `shortCode` serialises as `short` exactly like `TeamDto`, so team pills render from a row directly.
- `TeamService.getStandings()` now builds the full table itself: a private `TeamStats` accumulator (int fields internally, narrowed to `short` only at the DTO boundary, to avoid the compound-assignment narrowing trap already documented on `Team.addPoints`), a comparator implementing points → GD → GF → name, and `afterQueue` taken as the max queue of the finished matches. Every team from `teamRepository.findAll()` is ranked, so teams with no finished match now appear with zeroed stats at the bottom instead of relying on a separate `findAllByIdNotIn` query (removed from `TeamRepository` along with the old `// TODO probably this if could be removed`).
- `MatchService.calculatePointsForTeams` is untouched — the difficulty/staffing path still uses the transient `Team.points`/`place` fields. Deduplicating that (and removing the transient fields from the entity, the "modelowanie `Team.place`" note in the ticket) is deliberately left to RS-72-adjacent work; the two code paths share the points constants.

**Frontend**

- New `model/standing.ts` (`Standing extends Team`, `Standings` wrapper); `TeamService.getStandings(): Observable<Standings>`.
- `standings.component` — single HTTP call; `computeStats`/`latestPlayedQueue` deleted; rows, `place` and the "after queue N" subtitle come from the response; zone logic (top/bottom 3) stays client-side as pure presentation.
- `team-list.component` — single HTTP call; `countPlayed` and the `MatchService` dependency deleted; "Played" renders `row.played`.
- `staffer.component` / `match-detail.component` — consume `rows`; `place` lookups use the backend value instead of `index + 1`.
- `match-detail.component` — the "Team comparison" panel gains Wins / Draws / Losses / Goals for / Goals against rows, and the "requires a per-team season-stats endpoint" placeholder note is removed — this PR delivers that endpoint.

# Testing

- **Backend:** `mvn -DskipFrontend=true test` — all Spock specs green. `TeamServiceSpec` rewritten (full-table computation, tie-breaker chain, pre-season alphabetical table, empty league); `TeamControllerSpec` asserts the new JSON shape including the wire-format `short` field and that the converter is no longer touched on this endpoint.
- **Frontend:** `npm ci`, `npm run lint` (clean), `npm test` headless — 137/137 specs pass; `npm run build` also run to catch strict template errors. Standings/team-list specs now mock the wrapper response; the staffer spec's fixture carries backend `place`.

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_013yBbY5mngAdXdxvrKWjrgV)_