### PR TITLE
RS-71: Move match reference resolution from MatchConverter to MatchService

### DIFF
--- a/src/main/java/com/jamex/refereestaffer/controller/MatchController.java
+++ b/src/main/java/com/jamex/refereestaffer/controller/MatchController.java
@@ -64,18 +64,14 @@ public class MatchController {
     @PostMapping
     public MatchDto createMatch(@RequestBody MatchDto matchDto) {
         log.info("Adding new match");
-        var match = matchConverter.convertFromDto(matchDto);
-        var savedMatch = matchRepository.save(match);
-        return matchConverter.convertFromEntity(savedMatch);
+        return matchService.saveMatch(matchDto);
     }
 
     // TODO is this id needed?
     @PutMapping("/{id}")
     public MatchDto updateMatch(@RequestBody MatchDto matchDto, @PathVariable Long id) {
         log.info("Updating match with id {}", matchDto.getId());
-        var match = matchConverter.convertFromDto(matchDto);
-        var updatedMatch = matchRepository.save(match);
-        return matchConverter.convertFromEntity(updatedMatch);
+        return matchService.saveMatch(matchDto);
     }
 
     @PutMapping
@@ -84,8 +80,7 @@ public class MatchController {
                 .map(MatchDto::getId)
                 .toList();
         log.info("Updating matches with ids: {}", matchIds);
-        var matches = matchConverter.convertFromDtos(matchesDtos);
-        matchRepository.saveAll(matches);
+        matchService.updateMatches(matchesDtos);
     }
 
     @DeleteMapping

--- a/src/main/java/com/jamex/refereestaffer/model/converter/MatchConverter.java
+++ b/src/main/java/com/jamex/refereestaffer/model/converter/MatchConverter.java
@@ -4,28 +4,23 @@ import com.jamex.refereestaffer.model.dto.MatchDto;
 import com.jamex.refereestaffer.model.entity.Grade;
 import com.jamex.refereestaffer.model.entity.Match;
 import com.jamex.refereestaffer.model.entity.Referee;
-import com.jamex.refereestaffer.model.exception.TeamNotFoundException;
-import com.jamex.refereestaffer.repository.GradeRepository;
-import com.jamex.refereestaffer.repository.RefereeRepository;
-import com.jamex.refereestaffer.repository.TeamRepository;
+import com.jamex.refereestaffer.model.entity.Team;
 import org.springframework.stereotype.Component;
 
+import java.util.Collection;
 import java.util.Optional;
+import java.util.stream.StreamSupport;
 
+/**
+ * Pure mapping between {@link Match} and {@link MatchDto} — no repository access.
+ * Resolving ids to entities (teams, referee, grade) is the service layer's job
+ * ({@link com.jamex.refereestaffer.service.MatchService}), so the dto → entity
+ * direction takes already-resolved entities instead of implementing
+ * {@link BaseConverter#convertFromDto(Object)}.
+ */
 @Component
-public class MatchConverter implements BaseConverter<Match, MatchDto> {
+public class MatchConverter {
 
-    private final TeamRepository teamRepository;
-    private final RefereeRepository refereeRepository;
-    private final GradeRepository gradeRepository;
-
-    public MatchConverter(TeamRepository teamRepository, RefereeRepository refereeRepository, GradeRepository gradeRepository) {
-        this.teamRepository = teamRepository;
-        this.refereeRepository = refereeRepository;
-        this.gradeRepository = gradeRepository;
-    }
-
-    @Override
     public MatchDto convertFromEntity(Match entity) {
         var referee = Optional.ofNullable(entity.getReferee())
                 .map(Referee::getId);
@@ -45,25 +40,21 @@ public class MatchConverter implements BaseConverter<Match, MatchDto> {
                 entity.getHardnessLvl());
     }
 
-    @Override
-    public Match convertFromDto(MatchDto dto) {
-        var homeTeam = teamRepository.findById(dto.getHomeTeamId())
-                .orElseThrow(() -> new TeamNotFoundException(dto.getHomeTeamId()));
-        var awayTeam = teamRepository.findById(dto.getAwayTeamId())
-                .orElseThrow(() -> new TeamNotFoundException(dto.getAwayTeamId()));
-        var referee = Optional.ofNullable(dto.getRefereeId())
-                .flatMap(refereeRepository::findById);
-        var grade = Optional.ofNullable(dto.getGradeId())
-                .flatMap(gradeRepository::findById);
+    public Collection<MatchDto> convertFromEntities(final Iterable<Match> entities) {
+        return StreamSupport.stream(entities.spliterator(), false)
+                .map(this::convertFromEntity)
+                .toList();
+    }
 
+    public Match convertFromDto(MatchDto dto, Team home, Team away, Referee referee, Grade grade) {
         return new Match(
                 dto.getId(),
                 dto.getQueue(),
-                homeTeam,
-                awayTeam,
+                home,
+                away,
                 dto.getDate(),
-                referee.orElse(null),
-                grade.orElse(null),
+                referee,
+                grade,
                 dto.getHomeScore(),
                 dto.getAwayScore(),
                 0.0);

--- a/src/main/java/com/jamex/refereestaffer/service/MatchService.java
+++ b/src/main/java/com/jamex/refereestaffer/service/MatchService.java
@@ -1,13 +1,19 @@
 package com.jamex.refereestaffer.service;
 
+import com.jamex.refereestaffer.model.converter.MatchConverter;
 import com.jamex.refereestaffer.model.dto.DifficultyBreakdownDto;
+import com.jamex.refereestaffer.model.dto.MatchDto;
 import com.jamex.refereestaffer.model.entity.ConfigName;
+import com.jamex.refereestaffer.model.entity.Grade;
 import com.jamex.refereestaffer.model.entity.Match;
+import com.jamex.refereestaffer.model.entity.Referee;
 import com.jamex.refereestaffer.model.entity.Team;
 import com.jamex.refereestaffer.model.exception.MatchNotFoundException;
+import com.jamex.refereestaffer.model.exception.TeamNotFoundException;
 import com.jamex.refereestaffer.repository.ConfigurationRepository;
 import com.jamex.refereestaffer.repository.GradeRepository;
 import com.jamex.refereestaffer.repository.MatchRepository;
+import com.jamex.refereestaffer.repository.RefereeRepository;
 import com.jamex.refereestaffer.repository.TeamRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +22,9 @@ import org.springframework.stereotype.Service;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -31,13 +40,72 @@ public class MatchService {
     private final GradeRepository gradeRepository;
     private final ConfigurationRepository configurationRepository;
     private final TeamRepository teamRepository;
+    private final RefereeRepository refereeRepository;
+    private final MatchConverter matchConverter;
 
     public MatchService(MatchRepository matchRepository, GradeRepository gradeRepository,
-                        ConfigurationRepository configurationRepository, TeamRepository teamRepository) {
+                        ConfigurationRepository configurationRepository, TeamRepository teamRepository,
+                        RefereeRepository refereeRepository, MatchConverter matchConverter) {
         this.matchRepository = matchRepository;
         this.gradeRepository = gradeRepository;
         this.configurationRepository = configurationRepository;
         this.teamRepository = teamRepository;
+        this.refereeRepository = refereeRepository;
+        this.matchConverter = matchConverter;
+    }
+
+    public MatchDto saveMatch(MatchDto matchDto) {
+        var match = resolveAndConvert(List.of(matchDto)).get(0);
+        var savedMatch = matchRepository.save(match);
+        return matchConverter.convertFromEntity(savedMatch);
+    }
+
+    public void updateMatches(List<MatchDto> matchesDtos) {
+        var matches = resolveAndConvert(matchesDtos);
+        matchRepository.saveAll(matches);
+    }
+
+    /**
+     * Resolves the id references of each dto (teams, referee, grade) with one bulk
+     * query per repository and hands the ready entities to the converter — the
+     * converter itself does no repository access. A missing team is an error
+     * (404 via {@link TeamNotFoundException}); a missing referee or grade id maps
+     * to null, which is what the pre-refactor per-id lookups did too.
+     */
+    private List<Match> resolveAndConvert(List<MatchDto> matchesDtos) {
+        var teams = findByIds(teamRepository::findAllById, matchesDtos.stream()
+                .flatMap(dto -> Stream.of(dto.getHomeTeamId(), dto.getAwayTeamId())), Team::getId);
+        var referees = findByIds(refereeRepository::findAllById, matchesDtos.stream()
+                .map(MatchDto::getRefereeId), Referee::getId);
+        var grades = findByIds(gradeRepository::findAllById, matchesDtos.stream()
+                .map(MatchDto::getGradeId), Grade::getId);
+
+        return matchesDtos.stream()
+                .map(dto -> matchConverter.convertFromDto(dto,
+                        requireTeam(teams, dto.getHomeTeamId()),
+                        requireTeam(teams, dto.getAwayTeamId()),
+                        resolveOptional(referees, dto.getRefereeId()),
+                        resolveOptional(grades, dto.getGradeId())))
+                .toList();
+    }
+
+    private static <E> E resolveOptional(Map<Long, E> entitiesById, Long id) {
+        return id == null ? null : entitiesById.get(id);
+    }
+
+    private <E> Map<Long, E> findByIds(Function<List<Long>, List<E>> bulkFinder, Stream<Long> ids, Function<E, Long> idGetter) {
+        var distinctIds = ids.filter(Objects::nonNull).distinct().toList();
+        if (distinctIds.isEmpty())
+            return Map.of();
+        return bulkFinder.apply(distinctIds).stream()
+                .collect(Collectors.toMap(idGetter, Function.identity()));
+    }
+
+    private Team requireTeam(Map<Long, Team> teams, Long teamId) {
+        var team = teams.get(teamId);
+        if (team == null)
+            throw new TeamNotFoundException(teamId);
+        return team;
     }
 
     public void calculatePointsForTeams(List<Match> matches) {

--- a/src/test/groovy/com/jamex/refereestaffer/controller/MatchControllerSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/controller/MatchControllerSpec.groovy
@@ -130,10 +130,8 @@ class MatchControllerSpec extends Specification {
         response.status == 404
     }
 
-    def "should create match and return it as JSON"() {
+    def "should create match through the service and return it as JSON"() {
         given:
-        def match = [] as Match
-        def savedMatch = [] as Match
         def savedDto = MatchDto.builder().id(11l).queue(2 as Short).build()
 
         when:
@@ -143,20 +141,16 @@ class MatchControllerSpec extends Specification {
                 .andReturn().response
 
         then:
-        1 * matchConverter.convertFromDto({ MatchDto dto ->
+        1 * matchService.saveMatch({ MatchDto dto ->
             dto.queue == 2 as Short && dto.homeTeamId == 1l && dto.awayTeamId == 2l
-        }) >> match
-        1 * matchRepository.save(match) >> savedMatch
-        1 * matchConverter.convertFromEntity(savedMatch) >> savedDto
+        }) >> savedDto
         response.status == 200
         def json = new JsonSlurper().parseText(response.contentAsString)
         json.id == 11
     }
 
-    def "should update match"() {
+    def "should update match through the service"() {
         given:
-        def match = [] as Match
-        def updatedMatch = [] as Match
         def updatedDto = MatchDto.builder().id(11l).build()
 
         when:
@@ -166,16 +160,11 @@ class MatchControllerSpec extends Specification {
                 .andReturn().response
 
         then:
-        1 * matchConverter.convertFromDto({ MatchDto dto -> dto.id == 11l }) >> match
-        1 * matchRepository.save(match) >> updatedMatch
-        1 * matchConverter.convertFromEntity(updatedMatch) >> updatedDto
+        1 * matchService.saveMatch({ MatchDto dto -> dto.id == 11l }) >> updatedDto
         response.status == 200
     }
 
-    def "should update matches in bulk"() {
-        given:
-        def matches = [[] as Match, [] as Match]
-
+    def "should update matches in bulk through the service"() {
         when:
         def response = mockMvc.perform(put("/api/matches")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -183,8 +172,7 @@ class MatchControllerSpec extends Specification {
                 .andReturn().response
 
         then:
-        1 * matchConverter.convertFromDtos({ List<MatchDto> dtos -> dtos*.id == [1l, 2l] }) >> matches
-        1 * matchRepository.saveAll(matches)
+        1 * matchService.updateMatches({ List<MatchDto> dtos -> dtos*.id == [1l, 2l] })
         response.status == 200
     }
 

--- a/src/test/groovy/com/jamex/refereestaffer/model/converter/MatchConverterSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/model/converter/MatchConverterSpec.groovy
@@ -5,25 +5,15 @@ import com.jamex.refereestaffer.model.entity.Grade
 import com.jamex.refereestaffer.model.entity.Match
 import com.jamex.refereestaffer.model.entity.Referee
 import com.jamex.refereestaffer.model.entity.Team
-import com.jamex.refereestaffer.model.exception.TeamNotFoundException
-import com.jamex.refereestaffer.repository.GradeRepository
-import com.jamex.refereestaffer.repository.RefereeRepository
-import com.jamex.refereestaffer.repository.TeamRepository
 import spock.lang.Specification
 import spock.lang.Subject
+
+import java.time.LocalDateTime
 
 class MatchConverterSpec extends Specification {
 
     @Subject
-    MatchConverter matchConverter
-
-    TeamRepository teamRepository = Mock()
-    RefereeRepository refereeRepository = Mock()
-    GradeRepository gradeRepository = Mock()
-
-    def setup() {
-        matchConverter = new MatchConverter(teamRepository, refereeRepository, gradeRepository)
-    }
+    MatchConverter matchConverter = new MatchConverter()
 
     def "should convert from Match entity to dto"() {
         given:
@@ -57,36 +47,11 @@ class MatchConverterSpec extends Specification {
         [getId: { 11l }] as Referee | [getId: { 22l }] as Grade
     }
 
-    def "should throw TeamNotFoundException when home or away team has not been found"() {
-        given:
-        def correctTeamId = 1l
-        def wrongTeamId = 987l
-        def matchDto = MatchDto.builder()
-                .homeTeamId(homeTeamId)
-                .awayTeamId(awayTeamId)
-                .build()
-
-        when:
-        matchConverter.convertFromDto(matchDto)
-
-        then:
-        (0..1) * teamRepository.findById(correctTeamId) >> Optional.of([] as Team)
-        1 * teamRepository.findById(wrongTeamId) >> Optional.empty()
-        def exception = thrown(TeamNotFoundException)
-        exception.message == String.format(TeamNotFoundException.NOT_FOUND_WITH_ID, wrongTeamId)
-
-        where:
-        homeTeamId | awayTeamId
-        1l         | 987l
-        987l       | 1l
-    }
-
-    def "should convert from dto to Match entity"() {
+    def "should convert from dto and resolved entities to Match entity"() {
         given:
         def homeTeam = [] as Team
         def awayTeam = [] as Team
-        def referee = [] as Referee
-        def grade = [] as Grade
+        def date = LocalDateTime.of(2026, 7, 12, 17, 0)
         def matchDto = MatchDto.builder()
                 .id(23l)
                 .queue(3 as short)
@@ -94,25 +59,28 @@ class MatchConverterSpec extends Specification {
                 .awayTeamId(55l)
                 .refereeId(7l)
                 .gradeId(9l)
+                .date(date)
                 .homeScore(0 as short)
                 .awayScore(1 as short)
                 .build()
 
         when:
-        def result = matchConverter.convertFromDto(matchDto)
+        def result = matchConverter.convertFromDto(matchDto, homeTeam, awayTeam, referee, grade)
 
         then:
-        1 * teamRepository.findById(matchDto.homeTeamId) >> Optional.of(homeTeam)
-        1 * teamRepository.findById(matchDto.awayTeamId) >> Optional.of(awayTeam)
-        1 * refereeRepository.findById(matchDto.refereeId) >> Optional.of(referee)
-        1 * gradeRepository.findById(matchDto.gradeId) >> Optional.of(grade)
         result.id == matchDto.id
         result.queue == matchDto.queue
+        result.date == matchDto.date
         result.homeScore == matchDto.homeScore
         result.awayScore == matchDto.awayScore
         result.home == homeTeam
         result.away == awayTeam
         result.referee == referee
         result.grade == grade
+
+        where:
+        referee        | grade
+        null           | null
+        [] as Referee  | [] as Grade
     }
 }

--- a/src/test/groovy/com/jamex/refereestaffer/service/MatchServiceSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/service/MatchServiceSpec.groovy
@@ -1,10 +1,14 @@
 package com.jamex.refereestaffer.service
 
+import com.jamex.refereestaffer.model.converter.MatchConverter
+import com.jamex.refereestaffer.model.dto.MatchDto
 import com.jamex.refereestaffer.model.entity.*
 import com.jamex.refereestaffer.model.exception.MatchNotFoundException
+import com.jamex.refereestaffer.model.exception.TeamNotFoundException
 import com.jamex.refereestaffer.repository.ConfigurationRepository
 import com.jamex.refereestaffer.repository.GradeRepository
 import com.jamex.refereestaffer.repository.MatchRepository
+import com.jamex.refereestaffer.repository.RefereeRepository
 import com.jamex.refereestaffer.repository.TeamRepository
 import spock.lang.Specification
 import spock.lang.Subject
@@ -18,9 +22,139 @@ class MatchServiceSpec extends Specification {
     GradeRepository gradeRepository = Mock()
     ConfigurationRepository configurationRepository = Mock()
     TeamRepository teamRepository = Mock()
+    RefereeRepository refereeRepository = Mock()
 
     def setup() {
-        matchService = new MatchService(matchRepository, gradeRepository, configurationRepository, teamRepository)
+        // The converter is a pure mapper since RS-71, so the real one is used instead of a mock —
+        // these features then cover the whole resolve-references + convert path end to end.
+        matchService = new MatchService(matchRepository, gradeRepository, configurationRepository,
+                teamRepository, refereeRepository, new MatchConverter())
+    }
+
+    def "should save match with references resolved by bulk queries"() {
+        given:
+        def homeTeam = [getId: { 1l }] as Team
+        def awayTeam = [getId: { 2l }] as Team
+        def referee = [getId: { 7l }] as Referee
+        def grade = [getId: { 9l }] as Grade
+        def matchDto = MatchDto.builder()
+                .id(23l)
+                .queue(3 as short)
+                .homeTeamId(1l)
+                .awayTeamId(2l)
+                .refereeId(7l)
+                .gradeId(9l)
+                .build()
+
+        when:
+        def result = matchService.saveMatch(matchDto)
+
+        then:
+        1 * teamRepository.findAllById([1l, 2l]) >> [homeTeam, awayTeam]
+        1 * refereeRepository.findAllById([7l]) >> [referee]
+        1 * gradeRepository.findAllById([9l]) >> [grade]
+        1 * matchRepository.save({ Match match ->
+            match.home == homeTeam && match.away == awayTeam && match.referee == referee && match.grade == grade
+        }) >> { Match match -> match }
+        result.id == matchDto.id
+        result.queue == matchDto.queue
+        result.homeTeamId == 1l
+        result.awayTeamId == 2l
+        result.refereeId == 7l
+        result.gradeId == 9l
+    }
+
+    def "should save match without optional references and skip their queries"() {
+        given:
+        def homeTeam = [getId: { 1l }] as Team
+        def awayTeam = [getId: { 2l }] as Team
+        def matchDto = MatchDto.builder()
+                .queue(3 as short)
+                .homeTeamId(1l)
+                .awayTeamId(2l)
+                .build()
+
+        when:
+        def result = matchService.saveMatch(matchDto)
+
+        then:
+        1 * teamRepository.findAllById([1l, 2l]) >> [homeTeam, awayTeam]
+        0 * refereeRepository.findAllById(_)
+        0 * gradeRepository.findAllById(_)
+        1 * matchRepository.save({ Match match -> match.referee == null && match.grade == null }) >> { Match match -> match }
+        result.refereeId == null
+        result.gradeId == null
+    }
+
+    def "should resolve unknown referee and grade ids to null when saving match"() {
+        given:
+        def homeTeam = [getId: { 1l }] as Team
+        def awayTeam = [getId: { 2l }] as Team
+        def matchDto = MatchDto.builder()
+                .queue(3 as short)
+                .homeTeamId(1l)
+                .awayTeamId(2l)
+                .refereeId(7l)
+                .gradeId(9l)
+                .build()
+
+        when:
+        matchService.saveMatch(matchDto)
+
+        then:
+        1 * teamRepository.findAllById([1l, 2l]) >> [homeTeam, awayTeam]
+        1 * refereeRepository.findAllById([7l]) >> []
+        1 * gradeRepository.findAllById([9l]) >> []
+        1 * matchRepository.save({ Match match -> match.referee == null && match.grade == null }) >> { Match match -> match }
+    }
+
+    def "should throw TeamNotFoundException when home or away team has not been found"() {
+        given:
+        def correctTeamId = 1l
+        def wrongTeamId = 987l
+        def correctTeam = [getId: { correctTeamId }] as Team
+        def matchDto = MatchDto.builder()
+                .homeTeamId(homeTeamId)
+                .awayTeamId(awayTeamId)
+                .build()
+
+        when:
+        matchService.saveMatch(matchDto)
+
+        then:
+        1 * teamRepository.findAllById({ it.toSet() == [correctTeamId, wrongTeamId].toSet() }) >> [correctTeam]
+        def exception = thrown(TeamNotFoundException)
+        exception.message == String.format(TeamNotFoundException.NOT_FOUND_WITH_ID, wrongTeamId)
+
+        where:
+        homeTeamId | awayTeamId
+        1l         | 987l
+        987l       | 1l
+    }
+
+    def "should bulk update matches with a single query per repository"() {
+        given:
+        def team1 = [getId: { 1l }] as Team
+        def team2 = [getId: { 2l }] as Team
+        def team3 = [getId: { 3l }] as Team
+        def referee = [getId: { 7l }] as Referee
+        def matchesDtos = [
+                MatchDto.builder().id(31l).queue(3 as short).homeTeamId(1l).awayTeamId(2l).refereeId(7l).build(),
+                MatchDto.builder().id(32l).queue(3 as short).homeTeamId(2l).awayTeamId(3l).build()
+        ]
+
+        when:
+        matchService.updateMatches(matchesDtos)
+
+        then:
+        1 * teamRepository.findAllById([1l, 2l, 3l]) >> [team1, team2, team3]
+        1 * refereeRepository.findAllById([7l]) >> [referee]
+        0 * gradeRepository.findAllById(_)
+        1 * matchRepository.saveAll({ List<Match> matches ->
+            matches*.id == [31l, 32l] &&
+                    matches[0].home == team1 && matches[0].away == team2 && matches[0].referee == referee &&
+                    matches[1].home == team2 && matches[1].away == team3 && matches[1].referee == null
+        })
     }
 
     def "should throw MatchNotFoundException when match has not been found"() {


### PR DESCRIPTION
## Ticket

[RS-71: MatchConverter bez repozytoriów — rozwiązywanie referencji w serwisie](https://referee-staffer.youtrack.cloud/issue/RS-71)

`MatchConverter` injected three repositories (`TeamRepository`, `RefereeRepository`, `GradeRepository`) and queried the database on every DTO → entity conversion. The conversion layer should be pure mapping (SRP) — and because `BaseConverter.convertFromDtos` maps element by element, the bulk `PUT /api/matches` endpoint issued 2–4 hidden queries **per match** (a classic N+1). The ticket asks to move id → entity resolution to the service layer and hand the converter ready entities.

## Plan

1. **`MatchConverter`** — drop the repository dependencies; keep `convertFromEntity`/`convertFromEntities`; change `convertFromDto` to take already-resolved `Team`/`Referee`/`Grade` entities. Since the dto → entity half now needs context, the class stops implementing `BaseConverter` (nothing uses that interface polymorphically; the other four converters keep it).
2. **`MatchService`** — add `saveMatch(MatchDto)` and `updateMatches(List<MatchDto>)`, with a shared private resolution step that loads all referenced entities in bulk (`findAllById`, one query per repository) and preserves the existing semantics: missing team → `TeamNotFoundException` (404), missing/null referee or grade id → `null` on the entity.
3. **`MatchController`** — delegate `POST /api/matches`, `PUT /api/matches/{id}` and `PUT /api/matches` to the service; GET endpoints keep using the repository + entity → DTO conversion as before.
4. **Tests** — rewrite `MatchConverterSpec` as a pure spec (no mocks), move the `TeamNotFoundException` case to `MatchServiceSpec`, cover the new resolution logic (bulk queries, optional refs, unknown ids), update `MatchControllerSpec` stubs to the service methods. Run `mvn -DskipFrontend=true test`.

Risks considered: behaviour parity of the not-found semantics (kept exactly), and Spring context wiring (`StafferService` uses only the entity → DTO direction, so it is unaffected; no dependency cycle is introduced — `MatchService` → `MatchConverter` is one-way).

## Changes

- `MatchConverter` is now a pure, dependency-free mapper. `convertFromDto(MatchDto, Team, Team, Referee, Grade)` just builds the entity. It no longer implements `BaseConverter`, so it declares its own `convertFromEntities` (same 3-line stream as the interface default).
- `MatchService` gained `saveMatch`/`updateMatches` plus a private `resolveAndConvert` that collects all team/referee/grade ids from the DTOs and loads each entity type with **one** `findAllById` — the bulk update endpoint went from ~2–4 queries per match to 3 queries total. Single create/update reuses the same path with a one-element list.
- Missing-reference semantics are unchanged: unknown team id throws `TeamNotFoundException` (checked home first, then away, per DTO — same order as the old per-id lookups), unknown or null referee/grade ids resolve to `null`.
- `MatchController` POST/PUT endpoints are thin delegates to `MatchService` now; both single-match endpoints use the same `saveMatch` (their bodies were previously identical).
- Out of scope, left as-is: `GradeConverter` and `VacationConverter` have the same repository-in-converter smell — worth a follow-up ticket if desired.

## Testing

- `MatchConverterSpec` rewritten as a pure spec — no repository mocks left.
- `MatchServiceSpec`: 5 new features covering resolution — happy path with all references, optional refs absent (verifies referee/grade queries are skipped entirely), unknown referee/grade ids resolving to null, `TeamNotFoundException` for a missing home/away team, and bulk update asserting exactly one `findAllById` per repository.
- `MatchControllerSpec`: POST/PUT features now stub `MatchService` instead of converter + repository.
- Full backend suite: `mvn -DskipFrontend=true test` → **136 tests, 0 failures** (on JDK 25). Frontend untouched.

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01R61MigTZJQ3QcyLphf3crD)_