### PR TITLE
RS-72: Replace Referee.busy transient with local assigned-ids set in StafferService

### DIFF
--- a/src/main/java/com/jamex/refereestaffer/model/converter/RefereeConverter.java
+++ b/src/main/java/com/jamex/refereestaffer/model/converter/RefereeConverter.java
@@ -33,7 +33,6 @@ public class RefereeConverter implements BaseConverter<Referee, RefereeDto> {
                 dto.getExperience(),
                 null,
                 null,
-                null,
-                false);
+                null);
     }
 }

--- a/src/main/java/com/jamex/refereestaffer/model/entity/Referee.java
+++ b/src/main/java/com/jamex/refereestaffer/model/entity/Referee.java
@@ -41,9 +41,6 @@ public class Referee {
     @Transient
     private Map<Team, Short> teamsRefereed;
 
-    @Transient
-    private boolean busy;
-
     /**
      * Highest queue this referee has been assigned to. Set by
      * {@link com.jamex.refereestaffer.service.RefereeService#calculateStats}; null when
@@ -73,7 +70,7 @@ public class Referee {
     }
 
     public Referee(Long id, String firstName, String lastName, String email, List<Match> matches, int experience,
-                   Double averageGrade, Short numberOfMatchesInRound, Map<Team, Short> teamsRefereed, boolean busy) {
+                   Double averageGrade, Short numberOfMatchesInRound, Map<Team, Short> teamsRefereed) {
         this.id = id;
         this.firstName = firstName;
         this.lastName = lastName;
@@ -83,7 +80,6 @@ public class Referee {
         this.averageGrade = averageGrade;
         this.numberOfMatchesInRound = numberOfMatchesInRound;
         this.teamsRefereed = teamsRefereed;
-        this.busy = busy;
     }
 
     public Referee(String firstName, String lastName) {
@@ -146,14 +142,6 @@ public class Referee {
         this.teamsRefereed = teamsRefereed;
     }
 
-    public boolean isBusy() {
-        return busy;
-    }
-
-    public void setBusy(boolean busy) {
-        this.busy = busy;
-    }
-
     public Short getLastQueue() {
         return lastQueue;
     }
@@ -207,7 +195,6 @@ public class Referee {
         private Double averageGrade;
         private Short numberOfMatchesInRound;
         private Map<Team, Short> teamsRefereed;
-        private boolean busy;
 
         public Builder id(Long id) {
             this.id = id;
@@ -254,14 +241,9 @@ public class Referee {
             return this;
         }
 
-        public Builder busy(boolean busy) {
-            this.busy = busy;
-            return this;
-        }
-
         public Referee build() {
             return new Referee(id, firstName, lastName, email, matches, experience,
-                    averageGrade, numberOfMatchesInRound, teamsRefereed, busy);
+                    averageGrade, numberOfMatchesInRound, teamsRefereed);
         }
     }
 }

--- a/src/main/java/com/jamex/refereestaffer/service/StafferService.java
+++ b/src/main/java/com/jamex/refereestaffer/service/StafferService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +59,7 @@ public class StafferService {
     }
 
     private void assignRefereesToMatches(List<Referee> referees, List<Match> matches, Map<ConfigName, Double> config) {
+        var assignedRefereeIds = new HashSet<Long>();
         for (var match : matches) {
             var refereesPotentialLvlMap = new HashMap<Referee, Double>();
             var vacations = vacationRepository.findAllByStartDateIsLessThanEqualAndEndDateIsGreaterThanEqual(match.getDate());
@@ -67,7 +69,7 @@ public class StafferService {
                     .toList();
 
             var availableReferees = referees.stream()
-                    .filter(ref -> !ref.isBusy())
+                    .filter(ref -> !assignedRefereeIds.contains(ref.getId()))
                     .filter(ref -> !refereesWithVacations.contains(ref))
                     .toList();
 
@@ -84,8 +86,7 @@ public class StafferService {
             var chosenReferee = sortedRefereesPotentialLvlMap.keySet().stream()
                     .findFirst()
                     .orElseThrow(StafferException::new);
-            // TODO separate list for assigned referees id - get rid off field busy
-            chosenReferee.setBusy(true);
+            assignedRefereeIds.add(chosenReferee.getId());
 
             match.setReferee(chosenReferee);
         }

--- a/src/test/groovy/com/jamex/refereestaffer/service/StafferServiceSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/service/StafferServiceSpec.groovy
@@ -37,9 +37,21 @@ class StafferServiceSpec extends Specification {
                 .build()
         // After RefereeService.calculateStats, averageGrade is always non-null — the
         // no-grades fallback (DEFAULT_GRADE = 8.3) is applied there. Setting it
-        // explicitly here mirrors the real invariant.
-        def ref1 = [averageGrade: 8.1d, teamsRefereed: Map.of(team1, (short) 1, team2, (short) 1), numberOfMatchesInRound: 7] as Referee
-        def ref2 = [averageGrade: RefereeService.DEFAULT_GRADE, experience: 100, teamsRefereed: [:], numberOfMatchesInRound: 0] as Referee
+        // explicitly here mirrors the real invariant. Ids are needed because the
+        // staffer deduplicates already-assigned referees by id.
+        def ref1 = Referee.builder()
+                .id(1L)
+                .averageGrade(8.1d)
+                .teamsRefereed(Map.of(team1, (short) 1, team2, (short) 1))
+                .numberOfMatchesInRound((short) 7)
+                .build()
+        def ref2 = Referee.builder()
+                .id(2L)
+                .averageGrade(RefereeService.DEFAULT_GRADE)
+                .experience(100)
+                .teamsRefereed([:])
+                .numberOfMatchesInRound((short) 0)
+                .build()
         def match1 = Match.builder()
                 .home(team1)
                 .away(team2)
@@ -82,12 +94,12 @@ class StafferServiceSpec extends Specification {
 
     def "should not assign referees to matches if referee has vacation"() {
         given:
-        def ref1 = [averageGrade: 8.6d] as Referee
-        def ref2 = [averageGrade: RefereeService.DEFAULT_GRADE, teamsRefereed: [:], numberOfMatchesInRound: 0] as Referee
-        def ref3 = [averageGrade: RefereeService.DEFAULT_GRADE, teamsRefereed: [:], numberOfMatchesInRound: 0] as Referee
-        def ref4 = [averageGrade: 8.6d] as Referee
-        def ref5 = [averageGrade: 8.6d] as Referee
-        def ref6 = [averageGrade: 8.6d] as Referee
+        def ref1 = Referee.builder().id(1L).averageGrade(8.6d).build()
+        def ref2 = Referee.builder().id(2L).averageGrade(RefereeService.DEFAULT_GRADE).teamsRefereed([:]).numberOfMatchesInRound((short) 0).build()
+        def ref3 = Referee.builder().id(3L).averageGrade(RefereeService.DEFAULT_GRADE).teamsRefereed([:]).numberOfMatchesInRound((short) 0).build()
+        def ref4 = Referee.builder().id(4L).averageGrade(8.6d).build()
+        def ref5 = Referee.builder().id(5L).averageGrade(8.6d).build()
+        def ref6 = Referee.builder().id(6L).averageGrade(8.6d).build()
         def referees = [ref1, ref2, ref3, ref4, ref5, ref6]
         def matchDateTime = LocalDateTime.of(2022, 10, 12, 16, 0)
         def matchDate = matchDateTime.toLocalDate()


### PR DESCRIPTION
## Ticket

[RS-72](https://referee-staffer.youtrack.cloud/issue/RS-72) — *Referee.busy → Set&lt;Long&gt; w StafferService (stan procesu poza encją)*

The `Referee` JPA entity carried a `@Transient boolean busy` field that existed only to mark a referee as "already assigned" during a single staffing run. That mixes transient process state of the staffing algorithm into the domain model (an anti-pattern flagged by a long-standing `TODO` in `StafferService`). The goal was a pure refactor: move that bookkeeping into `StafferService` itself and remove the field from the entity, with no behavior change.

## Plan

1. In `StafferService.assignRefereesToMatches`, introduce a local `Set<Long> assignedRefereeIds` scoped to one staffing run; replace the `!ref.isBusy()` filter with `!assignedRefereeIds.contains(ref.getId())` and record `chosenReferee.getId()` after each assignment; drop the `TODO` and the `setBusy(true)` call.
2. Remove `busy` from the `Referee` entity: field, `isBusy()`/`setBusy()`, the all-args constructor parameter, and the builder field/method.
3. Update the only other caller of the all-args constructor, `RefereeConverter.convertFromDto`, to drop the trailing `false` argument.
4. Adjust `StafferServiceSpec` setups: referees in the two multi-referee features now need ids (deduplication is id-based, and the entity intentionally has no id setter, so map coercion can't provide one) — switch those setups to `Referee.builder()` with explicit ids. The ticket explicitly anticipated such minor setup fixes.
5. Run `mvn -DskipFrontend=true test` and confirm the whole backend suite is green.

## Changes

- `StafferService`: `assignRefereesToMatches` now tracks assigned referees in a local `HashSet<Long>` created at the start of each run, so the "busy" state lives and dies with a single `staffReferees` call — same lifecycle the transient field effectively had (entities were reloaded fresh each transaction), but now explicit and confined to the service.
- `Referee`: the `busy` field is gone from the entity, its all-args constructor, and the nested `Builder`.
- `RefereeConverter.convertFromDto`: constructor call updated accordingly.
- `StafferServiceSpec`: referee fixtures in "should assign referees to matches in queue" and "should not assign referees to matches if referee has vacation" are built with `Referee.builder()` and explicit ids (`1L`…`6L`). Without ids, all fixtures would share a `null` id and the id-based dedup would wrongly exclude every remaining referee after the first assignment. Production code always has DB-generated ids, so this is a test-fixture concern only.

Design decision: deduplication is by id (`Set<Long>`), as specified in the ticket, rather than by entity instance. Within one run the referee list comes from a single repository call, so both would work, but id-based tracking doesn't depend on instance identity or on `Referee` not overriding `equals`.

## Testing

- `mvn -DskipFrontend=true test` — all 130 Spock specs pass, including `StafferServiceSpec` (10 features, assignment + vacation + no-referee paths) and `StafferIntegrationSpec` (real Spring context + H2, verifies assignment persists).
- No frontend changes, so the frontend suite is untouched.

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5y5wB8x23ReggCU4bMb6R)_