### PR TITLE
RS-73: Lock-aware staffing regenerate

### DIFF
--- a/src/main/java/com/jamex/refereestaffer/controller/StafferController.java
+++ b/src/main/java/com/jamex/refereestaffer/controller/StafferController.java
@@ -1,15 +1,18 @@
 package com.jamex.refereestaffer.controller;
 
 import com.jamex.refereestaffer.model.dto.MatchDto;
+import com.jamex.refereestaffer.model.request.StaffingLockRequest;
 import com.jamex.refereestaffer.service.StafferService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Collection;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/staffer")
@@ -26,10 +29,16 @@ public class StafferController {
     /**
      * POST, not GET: staffing assigns referees and persists the result, so the verb must
      * signal the state change (was GET until 2026-07, which broke HTTP semantics).
+     *
+     * <p>The optional body carries locked (matchId, refereeId) pairs the algorithm must
+     * keep as-is while it staffs the rest of the queue. No body / empty list means a full
+     * regenerate. Kept optional so pre-lock clients (plain POST with no body) still work.
      */
     @PostMapping("/{queue}")
-    public Collection<MatchDto> staffReferees(@PathVariable short queue) {
-        log.info("Generating cast for queue {}", queue);
-        return stafferService.staffReferees(queue);
+    public Collection<MatchDto> staffReferees(@PathVariable short queue,
+                                              @RequestBody(required = false) List<StaffingLockRequest> locks) {
+        var lockedPairs = locks == null ? List.<StaffingLockRequest>of() : locks;
+        log.info("Generating cast for queue {} with {} locked assignments", queue, lockedPairs.size());
+        return stafferService.staffReferees(queue, lockedPairs);
     }
 }

--- a/src/main/java/com/jamex/refereestaffer/model/entity/Referee.java
+++ b/src/main/java/com/jamex/refereestaffer/model/entity/Referee.java
@@ -102,6 +102,16 @@ public class Referee {
         return id;
     }
 
+    /**
+     * "S C" = "Sędzia z Centrali" (central-level referee assigned top-down by PZPN).
+     * The imported CSV stores such assignments with firstName="S", lastName="C" as a
+     * sentinel meaning "the staffer must not touch this match". Kept as a name-based
+     * sentinel for now — modelling it as an explicit flag is a separate ticket.
+     */
+    public boolean isCentralSentinel() {
+        return "S".equals(firstName) && "C".equals(lastName);
+    }
+
     public String getFirstName() {
         return firstName;
     }

--- a/src/main/java/com/jamex/refereestaffer/model/exception/StafferException.java
+++ b/src/main/java/com/jamex/refereestaffer/model/exception/StafferException.java
@@ -7,4 +7,8 @@ public class StafferException extends RuntimeException {
     public StafferException() {
         super(NOT_ENOUGH_REFEREES);
     }
+
+    public StafferException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/com/jamex/refereestaffer/model/request/StaffingLockRequest.java
+++ b/src/main/java/com/jamex/refereestaffer/model/request/StaffingLockRequest.java
@@ -1,0 +1,9 @@
+package com.jamex.refereestaffer.model.request;
+
+/**
+ * A single pre-pinned (match, referee) pair sent along with a staffing request.
+ * Locked pairs are applied verbatim: the referee is treated as busy and the match as
+ * already cast, so the staffing algorithm only assigns the remaining matches.
+ */
+public record StaffingLockRequest(Long matchId, Long refereeId) {
+}

--- a/src/main/java/com/jamex/refereestaffer/repository/MatchRepository.java
+++ b/src/main/java/com/jamex/refereestaffer/repository/MatchRepository.java
@@ -13,7 +13,7 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
 
     List<Match> findAllByRefereeIn(Collection<Referee> referees);
 
-    List<Match> findAllByQueueAndRefereeIsNull(Short queue);
+    List<Match> findAllByQueue(Short queue);
 
     List<Match> findAllByHomeScoreNotNullAndAwayScoreNotNull();
 }

--- a/src/main/java/com/jamex/refereestaffer/service/MatchService.java
+++ b/src/main/java/com/jamex/refereestaffer/service/MatchService.java
@@ -3,6 +3,7 @@ package com.jamex.refereestaffer.service;
 import com.jamex.refereestaffer.model.dto.DifficultyBreakdownDto;
 import com.jamex.refereestaffer.model.entity.ConfigName;
 import com.jamex.refereestaffer.model.entity.Match;
+import com.jamex.refereestaffer.model.entity.Referee;
 import com.jamex.refereestaffer.model.entity.Team;
 import com.jamex.refereestaffer.model.exception.MatchNotFoundException;
 import com.jamex.refereestaffer.repository.ConfigurationRepository;
@@ -72,11 +73,25 @@ public class MatchService {
         matchRepository.delete(match);
     }
 
+    /**
+     * Matches the staffer is allowed to (re)assign in a queue, hardest first. Staffing
+     * persists assignments immediately, so a regenerate must be able to reclaim matches
+     * cast by a previous run — hence "assignable" covers previously assigned matches too,
+     * with two exceptions that keep their referee:
+     * <ul>
+     *   <li>central assignments (the "S C" sentinel — see {@link Referee#isCentralSentinel()}),</li>
+     *   <li>finished matches (both scores present) — history must not be rewritten.</li>
+     * </ul>
+     * Unassigned matches are always included, finished or not, matching the old
+     * referee-is-null behavior.
+     */
     public List<Match> getMatchesToAssignInQueue(Short queue) {
         var allFinishedMatches = matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull();
         calculatePointsForTeams(allFinishedMatches);
 
-        var matchesToAssignInQueue = matchRepository.findAllByQueueAndRefereeIsNull(queue);
+        var matchesToAssignInQueue = matchRepository.findAllByQueue(queue).stream()
+                .filter(this::isAssignable)
+                .toList();
 
         // Config values and the team count are constant for the whole request — load them
         // once here instead of per match (used to be 4-5 findByName + count per iteration).
@@ -86,6 +101,16 @@ public class MatchService {
         return matchesToAssignInQueue.stream()
                 .sorted(Comparator.comparingDouble(Match::getHardnessLvl).reversed())
                 .toList();
+    }
+
+    private boolean isAssignable(Match match) {
+        if (match.getReferee() == null) {
+            return true;
+        }
+        if (match.getReferee().isCentralSentinel()) {
+            return false;
+        }
+        return match.getHomeScore() == null && match.getAwayScore() == null;
     }
 
     /**

--- a/src/main/java/com/jamex/refereestaffer/service/RefereeService.java
+++ b/src/main/java/com/jamex/refereestaffer/service/RefereeService.java
@@ -40,12 +40,10 @@ public class RefereeService {
 
     public List<Referee> getAvailableRefereesForQueue(Short queue) {
         return refereeRepository.findAllWithNoMatchInQueue(queue).stream()
-                // "S C" = "Sędzia z Centrali" (PZPN central-level referee assigned top-down).
-                // Such matches already have a referee set in the imported data and must not be
-                // reassigned by the staffer. The CSV stores these assignments with firstName="S",
-                // lastName="C" as a sentinel, so we filter them out of the available pool.
+                // Central "S C" assignments already have a referee set in the imported data
+                // and must not be reassigned by the staffer — see Referee#isCentralSentinel.
                 // TODO longer-term: model this as a Referee flag / separate column instead of a name sentinel.
-                .filter(referee -> !(referee.getFirstName().equals("S") && referee.getLastName().equals("C")))
+                .filter(referee -> !referee.isCentralSentinel())
                 .toList();
     }
 

--- a/src/main/java/com/jamex/refereestaffer/service/StafferService.java
+++ b/src/main/java/com/jamex/refereestaffer/service/StafferService.java
@@ -7,8 +7,12 @@ import com.jamex.refereestaffer.model.entity.Match;
 import com.jamex.refereestaffer.model.entity.Referee;
 import com.jamex.refereestaffer.model.entity.Team;
 import com.jamex.refereestaffer.model.entity.Vacation;
+import com.jamex.refereestaffer.model.exception.RefereeNotFoundException;
 import com.jamex.refereestaffer.model.exception.StafferException;
+import com.jamex.refereestaffer.model.request.StaffingLockRequest;
 import com.jamex.refereestaffer.repository.ConfigurationRepository;
+import com.jamex.refereestaffer.repository.MatchRepository;
+import com.jamex.refereestaffer.repository.RefereeRepository;
 import com.jamex.refereestaffer.repository.VacationRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,43 +22,120 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
 public class StafferService {
 
+    static final String LOCKED_MATCH_NOT_ASSIGNABLE = "Locked match with id = %d is not assignable in queue %d";
+    static final String DUPLICATE_LOCKED_MATCH = "Match with id = %d is locked more than once";
+    static final String DUPLICATE_LOCKED_REFEREE = "Referee with id = %d is locked to more than one match";
+
     private static final Logger log = LoggerFactory.getLogger(StafferService.class);
 
     private final ConfigurationRepository configurationRepository;
     private final VacationRepository vacationRepository;
+    private final MatchRepository matchRepository;
+    private final RefereeRepository refereeRepository;
     private final MatchConverter matchConverter;
     private final MatchService matchService;
     private final RefereeService refereeService;
 
     public StafferService(ConfigurationRepository configurationRepository, VacationRepository vacationRepository,
+                          MatchRepository matchRepository, RefereeRepository refereeRepository,
                           MatchConverter matchConverter, MatchService matchService, RefereeService refereeService) {
         this.configurationRepository = configurationRepository;
         this.vacationRepository = vacationRepository;
+        this.matchRepository = matchRepository;
+        this.refereeRepository = refereeRepository;
         this.matchConverter = matchConverter;
         this.matchService = matchService;
         this.refereeService = refereeService;
     }
 
+    // @Transactional must sit on this overload too: the delegation below is a self-invocation,
+    // so it bypasses the Spring proxy and would otherwise run without a transaction (entities
+    // detached, assignments never flushed — the exact bug StafferIntegrationSpec guards against).
     @Transactional
     public Collection<MatchDto> staffReferees(short queue) {
+        return staffReferees(queue, List.of());
+    }
+
+    /**
+     * (Re)generates the cast for a queue. Locked pairs pin a referee to a match up front:
+     * the match keeps that exact referee and the referee is unavailable for the rest of the
+     * cast. Every other assignable match (see {@link MatchService#getMatchesToAssignInQueue})
+     * is staffed from scratch, so a regenerate reshuffles previous auto-assignments instead
+     * of silently keeping them.
+     *
+     * <p>Locks deliberately bypass the vacation filter — a pinned pair is an explicit user
+     * decision, and rejecting it here would make the UI's lock state impossible to restore.
+     */
+    @Transactional
+    public Collection<MatchDto> staffReferees(short queue, List<StaffingLockRequest> locks) {
+        var sortedMatchesToStaff = matchService.getMatchesToAssignInQueue(queue);
+        applyLocks(queue, sortedMatchesToStaff, locks);
+        // Push the cleared/pinned assignments to the DB before querying availability —
+        // findAllWithNoMatchInQueue is a native query, so it only sees flushed state.
+        matchRepository.flush();
+
         var referees = refereeService.getAvailableRefereesForQueue(queue);
         refereeService.calculateStats(referees);
-        var sortedMatchesInQueue = matchService.getMatchesToAssignInQueue(queue);
         // Load all config values up front instead of hitting the DB per (referee × match) — see
         // countRefereePotentialLvl. With ~15 referees × ~8 matches that's 600 → 1 query.
         var config = configurationRepository.findAllAsMap();
 
-        assignRefereesToMatches(referees, sortedMatchesInQueue, config);
+        var matchesToAutoStaff = sortedMatchesToStaff.stream()
+                .filter(match -> match.getReferee() == null)
+                .toList();
+        assignRefereesToMatches(referees, matchesToAutoStaff, config);
 
-        return matchConverter.convertFromEntities(sortedMatchesInQueue);
+        return matchConverter.convertFromEntities(sortedMatchesToStaff);
+    }
+
+    /**
+     * Clears previous auto-assignments and pins the locked pairs. Clearing happens first so
+     * a lock may freely move a referee between matches within the queue.
+     */
+    private void applyLocks(short queue, List<Match> matchesToStaff, List<StaffingLockRequest> locks) {
+        validateLocks(queue, matchesToStaff, locks);
+
+        matchesToStaff.forEach(match -> match.setReferee(null));
+        if (locks.isEmpty()) {
+            return;
+        }
+
+        var matchesById = matchesToStaff.stream()
+                .collect(Collectors.toMap(Match::getId, Function.identity()));
+        for (var lock : locks) {
+            var referee = refereeRepository.findById(lock.refereeId())
+                    .orElseThrow(() -> new RefereeNotFoundException(lock.refereeId()));
+            matchesById.get(lock.matchId()).setReferee(referee);
+        }
+    }
+
+    private void validateLocks(short queue, List<Match> matchesToStaff, List<StaffingLockRequest> locks) {
+        var assignableMatchIds = matchesToStaff.stream()
+                .map(Match::getId)
+                .collect(Collectors.toSet());
+        var lockedMatchIds = new HashSet<Long>();
+        var lockedRefereeIds = new HashSet<Long>();
+        for (var lock : locks) {
+            if (!assignableMatchIds.contains(lock.matchId())) {
+                throw new StafferException(String.format(LOCKED_MATCH_NOT_ASSIGNABLE, lock.matchId(), queue));
+            }
+            if (!lockedMatchIds.add(lock.matchId())) {
+                throw new StafferException(String.format(DUPLICATE_LOCKED_MATCH, lock.matchId()));
+            }
+            if (!lockedRefereeIds.add(lock.refereeId())) {
+                throw new StafferException(String.format(DUPLICATE_LOCKED_REFEREE, lock.refereeId()));
+            }
+        }
     }
 
     private void assignRefereesToMatches(List<Referee> referees, List<Match> matches, Map<ConfigName, Double> config) {

--- a/src/main/java/com/jamex/refereestaffer/service/StafferService.java
+++ b/src/main/java/com/jamex/refereestaffer/service/StafferService.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -35,6 +36,7 @@ public class StafferService {
     static final String LOCKED_MATCH_NOT_ASSIGNABLE = "Locked match with id = %d is not assignable in queue %d";
     static final String DUPLICATE_LOCKED_MATCH = "Match with id = %d is locked more than once";
     static final String DUPLICATE_LOCKED_REFEREE = "Referee with id = %d is locked to more than one match";
+    static final String LOCKED_REFEREE_UNAVAILABLE = "Referee with id = %d already has a non-reassignable match in queue %d";
 
     private static final Logger log = LoggerFactory.getLogger(StafferService.class);
 
@@ -120,14 +122,29 @@ public class StafferService {
     }
 
     private void validateLocks(short queue, List<Match> matchesToStaff, List<StaffingLockRequest> locks) {
+        if (locks.isEmpty()) {
+            return;
+        }
         var assignableMatchIds = matchesToStaff.stream()
                 .map(Match::getId)
+                .collect(Collectors.toSet());
+        // Referees keeping an assignment in this queue (finished or central matches) cannot be
+        // pinned to another match — that would double-book them within the round. Unreachable
+        // through the UI (its candidate pool already excludes them) but reachable via raw API.
+        var unavailableRefereeIds = matchRepository.findAllByQueue(queue).stream()
+                .filter(match -> !assignableMatchIds.contains(match.getId()))
+                .map(Match::getReferee)
+                .filter(Objects::nonNull)
+                .map(Referee::getId)
                 .collect(Collectors.toSet());
         var lockedMatchIds = new HashSet<Long>();
         var lockedRefereeIds = new HashSet<Long>();
         for (var lock : locks) {
             if (!assignableMatchIds.contains(lock.matchId())) {
                 throw new StafferException(String.format(LOCKED_MATCH_NOT_ASSIGNABLE, lock.matchId(), queue));
+            }
+            if (unavailableRefereeIds.contains(lock.refereeId())) {
+                throw new StafferException(String.format(LOCKED_REFEREE_UNAVAILABLE, lock.refereeId(), queue));
             }
             if (!lockedMatchIds.add(lock.matchId())) {
                 throw new StafferException(String.format(DUPLICATE_LOCKED_MATCH, lock.matchId()));

--- a/src/main/webapp/src/app/component/staffer/staffer.component.html
+++ b/src/main/webapp/src/app/component/staffer/staffer.component.html
@@ -65,7 +65,7 @@
                [delta]="'Σ across ' + ms.length + ' matches'"></app-kpi>
       <app-kpi label="Locked assignments"
                [value]="lockCount() + '/' + ms.length"
-               [delta]="lockCount() > 0 ? 'Not yet preserved on regenerate' : 'All flexible'"></app-kpi>
+               [delta]="lockCount() > 0 ? 'Preserved on regenerate' : 'All flexible'"></app-kpi>
     </div>
   </div>
 

--- a/src/main/webapp/src/app/component/staffer/staffer.component.spec.ts
+++ b/src/main/webapp/src/app/component/staffer/staffer.component.spec.ts
@@ -135,7 +135,7 @@ describe('StafferComponent', () => {
       component.incQueue();
       component.generate();
 
-      expect(stafferService.staffReferees).toHaveBeenCalledWith(2);
+      expect(stafferService.staffReferees).toHaveBeenCalledWith(2, []);
       expect(refereeService.findRefereesAvailableForQueue).toHaveBeenCalledWith(2);
       expect(component.matches()).toEqual(matches);
       expect(component.referees()).toEqual(referees);
@@ -172,6 +172,15 @@ describe('StafferComponent', () => {
 
       component.generate();
       expect(component.savedAt()).toBeNull();
+    });
+
+    it('sends the locked pairs so a regenerate preserves them server-side', () => {
+      component.generate();
+      component.toggleLock(component.matches()![0]);
+
+      component.generate();
+
+      expect(stafferService.staffReferees).toHaveBeenCalledWith(1, [{matchId: 11, refereeId: 100}]);
     });
   });
 
@@ -218,6 +227,18 @@ describe('StafferComponent', () => {
       expect(component.lockCount()).toBe(2);
 
       component.clearLocks();
+      expect(component.lockCount()).toBe(0);
+    });
+
+    it('clears locks on queue change — they reference matches of the previous queue', () => {
+      component.toggleLock(component.matches()![0]);
+      expect(component.lockCount()).toBe(1);
+
+      component.incQueue();
+      expect(component.lockCount()).toBe(0);
+
+      component.toggleLock(component.matches()![0]);
+      component.decQueue();
       expect(component.lockCount()).toBe(0);
     });
   });

--- a/src/main/webapp/src/app/component/staffer/staffer.component.ts
+++ b/src/main/webapp/src/app/component/staffer/staffer.component.ts
@@ -33,10 +33,8 @@ const NUMBER_OF_EDGE_TEAMS = 3;
 
 /**
  * Staffer — the auto-assignment workspace. Pick a queue, generate the cast, lock or
- * swap individual rows, then save.
- *
- * Referee potential and the difficulty breakdown come from the backend; the one open
- * backend follow-up is lock-aware regenerate (see the `locks` field comment).
+ * swap individual rows, then save. Locked pairs are sent with the staffing request,
+ * so a regenerate preserves them server-side and reshuffles only the rest.
  */
 @Component({
   selector: 'app-staffer',
@@ -65,10 +63,10 @@ export class StafferComponent {
   readonly totalTeams = signal(0);
 
   /**
-   * UI-only lock map. A planned backend addition turns this into a backend-aware
-   * concept where `staffReferees(queue, locks)` accepts a list of pre-pinned
-   * (matchId, refereeId) pairs. For now, locks are visual flags only; clicking
-   * Generate cast re-staffs the whole queue without preserving them.
+   * Map<matchId, refereeId> of locked assignments. Sent with the staffing request:
+   * the backend pins each pair and re-staffs only the remaining matches, so locks
+   * survive a regenerate. Cleared on queue change — they reference matches of the
+   * previously generated queue.
    */
   readonly locks = signal<Map<number, number>>(new Map());
   readonly drawerMatchId = signal<number | null>(null);
@@ -101,10 +99,12 @@ export class StafferComponent {
 
   incQueue(): void {
     this.queue.update(q => q + 1);
+    this.clearLocks();
   }
 
   decQueue(): void {
     this.queue.update(q => Math.max(1, q - 1));
+    this.clearLocks();
   }
 
   clearLocks(): void {
@@ -114,8 +114,9 @@ export class StafferComponent {
   generate(): void {
     this.loading.set(true);
     this.savedAt.set(null);
+    const locks = Array.from(this.locks(), ([matchId, refereeId]) => ({matchId, refereeId}));
     forkJoin({
-      matches: this.stafferService.staffReferees(this.queue()),
+      matches: this.stafferService.staffReferees(this.queue(), locks),
       standings: this.teamService.getStandings(),
       referees: this.refereeService.findRefereesAvailableForQueue(this.queue())
     }).subscribe({

--- a/src/main/webapp/src/app/model/staffingLock.ts
+++ b/src/main/webapp/src/app/model/staffingLock.ts
@@ -1,0 +1,8 @@
+/**
+ * A pre-pinned (match, referee) pair sent with a staffing request. The backend keeps
+ * the pair as-is and staffs only the remaining matches of the queue.
+ */
+export interface StaffingLock {
+  matchId: number;
+  refereeId: number;
+}

--- a/src/main/webapp/src/app/service/staffer.service.ts
+++ b/src/main/webapp/src/app/service/staffer.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import {Observable} from "rxjs";
 import { HttpClient } from "@angular/common/http";
 import {Match} from "../model/match";
+import {StaffingLock} from "../model/staffingLock";
 import {environment} from "../../environments/environment";
 
 @Injectable({
@@ -13,8 +14,9 @@ export class StafferService {
 
   private readonly stafferUrl = `${environment.apiBaseUrl}/api/staffer`
 
-  public staffReferees(queue: number): Observable<Match[]> {
-    // POST — staffing mutates assignments server-side (empty body; queue is in the path).
-    return this.http.post<Match[]>(`${this.stafferUrl}/${queue}`, null)
+  public staffReferees(queue: number, locks: StaffingLock[] = []): Observable<Match[]> {
+    // POST — staffing mutates assignments server-side (queue is in the path). The body
+    // carries locked (matchId, refereeId) pairs the backend must keep while re-staffing.
+    return this.http.post<Match[]>(`${this.stafferUrl}/${queue}`, locks)
   }
 }

--- a/src/test/groovy/com/jamex/refereestaffer/controller/StafferControllerSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/controller/StafferControllerSpec.groovy
@@ -2,12 +2,14 @@ package com.jamex.refereestaffer.controller
 
 import com.jamex.refereestaffer.model.dto.MatchDto
 import com.jamex.refereestaffer.model.exception.StafferException
+import com.jamex.refereestaffer.model.request.StaffingLockRequest
 import com.jamex.refereestaffer.service.StafferService
 import groovy.json.JsonSlurper
 import org.spockframework.runtime.model.parallel.ExecutionMode
 import org.spockframework.spring.SpringBean
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import spock.lang.Execution
 import spock.lang.Specification
@@ -36,11 +38,28 @@ class StafferControllerSpec extends Specification {
         def response = mockMvc.perform(post("/api/staffer/12")).andReturn().response
 
         then:
-        1 * stafferService.staffReferees(12 as short) >> matchesInQueue
+        // No body means no locks — the controller must default to an empty list.
+        1 * stafferService.staffReferees(12 as short, []) >> matchesInQueue
         response.status == 200
         def json = new JsonSlurper().parseText(response.contentAsString)
         json*.id == [1, 2]
         json*.refereeId == [4, 7]
+    }
+
+    def "should pass locked assignments from the request body to the service"() {
+        given:
+        def body = '[{"matchId":1,"refereeId":4},{"matchId":2,"refereeId":7}]'
+        def expectedLocks = [new StaffingLockRequest(1l, 4l), new StaffingLockRequest(2l, 7l)]
+
+        when:
+        def response = mockMvc.perform(post("/api/staffer/12")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andReturn().response
+
+        then:
+        1 * stafferService.staffReferees(12 as short, expectedLocks) >> []
+        response.status == 200
     }
 
     // Staffing persists referee assignments, so the endpoint must not be reachable via a
@@ -50,7 +69,7 @@ class StafferControllerSpec extends Specification {
         def response = mockMvc.perform(get("/api/staffer/7")).andReturn().response
 
         then:
-        0 * stafferService.staffReferees(_)
+        0 * stafferService.staffReferees(_, _)
         response.status == 405
     }
 
@@ -59,7 +78,7 @@ class StafferControllerSpec extends Specification {
         def response = mockMvc.perform(post("/api/staffer/7")).andReturn().response
 
         then:
-        1 * stafferService.staffReferees(7 as short) >> { throw new StafferException() }
+        1 * stafferService.staffReferees(7 as short, []) >> { throw new StafferException() }
         response.status == 409
         def json = new JsonSlurper().parseText(response.contentAsString)
         json.detail == new StafferException().message

--- a/src/test/groovy/com/jamex/refereestaffer/integration/StafferIntegrationSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/integration/StafferIntegrationSpec.groovy
@@ -3,6 +3,7 @@ package com.jamex.refereestaffer.integration
 import com.jamex.refereestaffer.model.entity.Match
 import com.jamex.refereestaffer.model.entity.Referee
 import com.jamex.refereestaffer.model.entity.Team
+import com.jamex.refereestaffer.model.request.StaffingLockRequest
 import com.jamex.refereestaffer.repository.MatchRepository
 import com.jamex.refereestaffer.repository.RefereeRepository
 import com.jamex.refereestaffer.repository.TeamRepository
@@ -56,5 +57,53 @@ class StafferIntegrationSpec extends Specification {
         def persisted = matchRepository.findById(matchToStaff.id).orElseThrow()
         persisted.referee != null
         persisted.referee.id == referee.id
+    }
+
+    def "should preserve locked assignment and re-staff the rest on regenerate"() {
+        given:
+        def team1 = teamRepository.save(new Team("Team1", "City1"))
+        def team2 = teamRepository.save(new Team("Team2", "City2"))
+        def team3 = teamRepository.save(new Team("Team3", "City3"))
+        def team4 = teamRepository.save(new Team("Team4", "City4"))
+        def strongReferee = refereeRepository.save(new Referee("Strong", "Referee", "strong@referees.com", 10))
+        def weakReferee = refereeRepository.save(new Referee("Weak", "Referee", "weak@referees.com", 0))
+        short queue = 1
+        def match1 = matchRepository.save(
+                new Match(queue, team1, team2, LocalDateTime.now().plusDays(1), null, null, null))
+        def match2 = matchRepository.save(
+                new Match(queue, team3, team4, LocalDateTime.now().plusDays(1), null, null, null))
+
+        and: "a first staffing run has already persisted a full cast"
+        stafferService.staffReferees(queue)
+
+        when: "the cast is regenerated with match1 pinned to the weak referee"
+        stafferService.staffReferees(queue, [new StaffingLockRequest(match1.id, weakReferee.id)])
+
+        then: "the pinned pair survives and the other match is re-staffed from the remaining pool"
+        matchRepository.findById(match1.id).orElseThrow().referee.id == weakReferee.id
+        matchRepository.findById(match2.id).orElseThrow().referee.id == strongReferee.id
+    }
+
+    def "should not touch central assignments when regenerating"() {
+        given:
+        def team1 = teamRepository.save(new Team("Team1", "City1"))
+        def team2 = teamRepository.save(new Team("Team2", "City2"))
+        def team3 = teamRepository.save(new Team("Team3", "City3"))
+        def team4 = teamRepository.save(new Team("Team4", "City4"))
+        def centralReferee = refereeRepository.save(new Referee("S", "C"))
+        def realReferee = refereeRepository.save(new Referee("John", "Doe", "john@doe.com", 5))
+        short queue = 1
+        def centralMatch = matchRepository.save(
+                new Match(queue, team1, team2, LocalDateTime.now().plusDays(1), centralReferee, null, null))
+        def openMatch = matchRepository.save(
+                new Match(queue, team3, team4, LocalDateTime.now().plusDays(1), null, null, null))
+
+        when:
+        def result = stafferService.staffReferees(queue)
+
+        then: "the central assignment is kept and excluded from the returned cast"
+        matchRepository.findById(centralMatch.id).orElseThrow().referee.id == centralReferee.id
+        matchRepository.findById(openMatch.id).orElseThrow().referee.id == realReferee.id
+        result*.id == [openMatch.id]
     }
 }

--- a/src/test/groovy/com/jamex/refereestaffer/integration/StafferIntegrationSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/integration/StafferIntegrationSpec.groovy
@@ -8,8 +8,10 @@ import com.jamex.refereestaffer.repository.MatchRepository
 import com.jamex.refereestaffer.repository.RefereeRepository
 import com.jamex.refereestaffer.repository.TeamRepository
 import com.jamex.refereestaffer.service.StafferService
+import org.spockframework.runtime.model.parallel.ExecutionMode
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import spock.lang.Execution
 import spock.lang.Specification
 
 import java.time.LocalDateTime
@@ -20,6 +22,10 @@ import java.time.LocalDateTime
  * algorithm with mocks — this one's job is to prove that referee assignment actually
  * persists to the database, which is the part dependency-injected mocks can never verify.
  */
+// Features must run on one thread: they share the single cached H2 instance and setup()
+// wipes the domain tables, so Spock's parallel mode would let features delete each
+// other's fixtures mid-flight.
+@Execution(ExecutionMode.SAME_THREAD)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 class StafferIntegrationSpec extends Specification {
 

--- a/src/test/groovy/com/jamex/refereestaffer/service/MatchServiceSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/service/MatchServiceSpec.groovy
@@ -102,7 +102,7 @@ class MatchServiceSpec extends Specification {
         def expectedHardness = (matchHardnessIncrementer - Math.abs(awayTeam.points - homeTeam.points)) * matchHardnessLvlMultiplier
         result.get(0).hardnessLvl == expectedHardness
         1 * matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull() >> []
-        1 * matchRepository.findAllByQueueAndRefereeIsNull(queue) >> matches
+        1 * matchRepository.findAllByQueue(queue) >> matches
         // Deliberately no edge/top/bottom keys in the map — the unranked guard must return
         // before those values are ever read (a lookup would NPE and fail the test).
         1 * configurationRepository.findAllAsMap() >> [
@@ -143,7 +143,7 @@ class MatchServiceSpec extends Specification {
         else if (isBottomMatch) expectedHardnessLevel += matchHardnessBottomIncrementer
         result.get(0).hardnessLvl == expectedHardnessLevel
         1 * matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull() >> []
-        1 * matchRepository.findAllByQueueAndRefereeIsNull(queue) >> matches
+        1 * matchRepository.findAllByQueue(queue) >> matches
         1 * configurationRepository.findAllAsMap() >> [
                 (ConfigName.DIFFICULTY_LEVEL_MULTIPLIER)                : matchHardnessLvlMultiplier,
                 (ConfigName.DIFFICULTY_LEVEL_INCREMENTER)               : matchHardnessIncrementer,
@@ -162,6 +162,47 @@ class MatchServiceSpec extends Specification {
         3             | "city2"      | 2         | false   | false      | true
         1             | "city1"      | 2         | true    | true       | false
         3             | "city1"      | 2         | true    | false      | true
+    }
+
+    def "should include previously assigned matches but keep central and finished assignments"() {
+        given:
+        short queue = 2
+        def homeTeam = [points: 0, place: 0, city: "city1"] as Team
+        def awayTeam = [points: 0, place: 0, city: "city2"] as Team
+        def unassigned = Match.builder().home(homeTeam).away(awayTeam).build()
+        def assignedUnfinished = Match.builder()
+                .home(homeTeam).away(awayTeam)
+                .referee(new Referee("John", "Doe"))
+                .build()
+        def centralAssigned = Match.builder()
+                .home(homeTeam).away(awayTeam)
+                .referee(new Referee("S", "C"))
+                .build()
+        def finishedAssigned = Match.builder()
+                .home(homeTeam).away(awayTeam)
+                .referee(new Referee("Jane", "Smith"))
+                .homeScore((short) 2).awayScore((short) 1)
+                .build()
+        def finishedUnassigned = Match.builder()
+                .home(homeTeam).away(awayTeam)
+                .homeScore((short) 0).awayScore((short) 0)
+                .build()
+
+        when:
+        def result = matchService.getMatchesToAssignInQueue(queue)
+
+        then:
+        result.size() == 3
+        result.containsAll([unassigned, assignedUnfinished, finishedUnassigned])
+        !result.contains(centralAssigned)
+        !result.contains(finishedAssigned)
+        1 * matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull() >> []
+        1 * matchRepository.findAllByQueue(queue) >> [unassigned, assignedUnfinished, centralAssigned, finishedAssigned, finishedUnassigned]
+        1 * configurationRepository.findAllAsMap() >> [
+                (ConfigName.DIFFICULTY_LEVEL_MULTIPLIER) : 1.0d,
+                (ConfigName.DIFFICULTY_LEVEL_INCREMENTER): 100.0d
+        ]
+        1 * teamRepository.count() >> 3
     }
 
     def "should throw MatchNotFoundException when computing breakdown for missing match"() {

--- a/src/test/groovy/com/jamex/refereestaffer/service/StafferServiceSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/service/StafferServiceSpec.groovy
@@ -199,6 +199,7 @@ class StafferServiceSpec extends Specification {
         lockedMatch.referee == lockedReferee
         otherMatch.referee == freeReferee
         1 * matchService.getMatchesToAssignInQueue(queue) >> [lockedMatch, otherMatch]
+        1 * matchRepository.findAllByQueue(queue) >> [lockedMatch, otherMatch]
         1 * refereeRepository.findById(11l) >> Optional.of(lockedReferee)
         // Pinned state must be flushed before the native availability query runs.
         1 * matchRepository.flush()
@@ -246,11 +247,37 @@ class StafferServiceSpec extends Specification {
 
         then:
         1 * matchService.getMatchesToAssignInQueue(queue) >> [assignableMatch]
+        1 * matchRepository.findAllByQueue(queue) >> [assignableMatch]
         0 * refereeRepository.findById(_)
         0 * refereeService.getAvailableRefereesForQueue(_)
         def exception = thrown(StafferException)
         exception.message == String.format(StafferService.LOCKED_MATCH_NOT_ASSIGNABLE, 99l, queue)
         assignableMatch.referee == null
+    }
+
+    def "should reject lock pinning a referee who keeps a non-reassignable match in the queue"() {
+        given:
+        short queue = 4
+        def busyReferee = Referee.builder().id(11l).firstName("Busy").lastName("Referee").build()
+        def assignableMatch = Match.builder().id(1l).build()
+        def finishedMatch = Match.builder()
+                .id(2l)
+                .referee(busyReferee)
+                .homeScore((short) 1).awayScore((short) 0)
+                .build()
+        def locks = [new StaffingLockRequest(1l, 11l)]
+
+        when:
+        stafferService.staffReferees(queue, locks)
+
+        then:
+        1 * matchService.getMatchesToAssignInQueue(queue) >> [assignableMatch]
+        1 * matchRepository.findAllByQueue(queue) >> [assignableMatch, finishedMatch]
+        0 * refereeRepository.findById(_)
+        def exception = thrown(StafferException)
+        exception.message == String.format(StafferService.LOCKED_REFEREE_UNAVAILABLE, 11l, queue)
+        assignableMatch.referee == null
+        finishedMatch.referee == busyReferee
     }
 
     def "should reject duplicate locks"() {
@@ -263,6 +290,7 @@ class StafferServiceSpec extends Specification {
 
         then:
         1 * matchService.getMatchesToAssignInQueue(queue) >> matches
+        1 * matchRepository.findAllByQueue(queue) >> matches
         0 * refereeRepository.findById(_)
         def exception = thrown(StafferException)
         exception.message == expectedMessage
@@ -284,6 +312,7 @@ class StafferServiceSpec extends Specification {
 
         then:
         1 * matchService.getMatchesToAssignInQueue(queue) >> [match]
+        1 * matchRepository.findAllByQueue(queue) >> [match]
         1 * refereeRepository.findById(77l) >> Optional.empty()
         0 * refereeService.getAvailableRefereesForQueue(_)
         thrown(RefereeNotFoundException)

--- a/src/test/groovy/com/jamex/refereestaffer/service/StafferServiceSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/service/StafferServiceSpec.groovy
@@ -3,8 +3,12 @@ package com.jamex.refereestaffer.service
 import com.jamex.refereestaffer.model.converter.MatchConverter
 import com.jamex.refereestaffer.model.dto.MatchDto
 import com.jamex.refereestaffer.model.entity.*
+import com.jamex.refereestaffer.model.exception.RefereeNotFoundException
 import com.jamex.refereestaffer.model.exception.StafferException
+import com.jamex.refereestaffer.model.request.StaffingLockRequest
 import com.jamex.refereestaffer.repository.ConfigurationRepository
+import com.jamex.refereestaffer.repository.MatchRepository
+import com.jamex.refereestaffer.repository.RefereeRepository
 import com.jamex.refereestaffer.repository.VacationRepository
 import spock.lang.Specification
 import spock.lang.Subject
@@ -18,12 +22,15 @@ class StafferServiceSpec extends Specification {
 
     ConfigurationRepository configurationRepository = Mock()
     VacationRepository vacationRepository = Mock()
+    MatchRepository matchRepository = Mock()
+    RefereeRepository refereeRepository = Mock()
     MatchConverter matchConverter = Mock()
     MatchService matchService = Mock()
     RefereeService refereeService = Mock()
 
     def setup() {
-        stafferService = new StafferService(configurationRepository, vacationRepository, matchConverter, matchService, refereeService)
+        stafferService = new StafferService(configurationRepository, vacationRepository, matchRepository,
+                refereeRepository, matchConverter, matchService, refereeService)
     }
 
     def "should assign referees to matches in queue"() {
@@ -172,5 +179,123 @@ class StafferServiceSpec extends Specification {
         1 * vacationRepository.findAllByStartDateIsLessThanEqualAndEndDateIsGreaterThanEqual(matchDateTime) >> [vacation]
         0 * matchConverter.convertFromEntities(_)
         thrown(StafferException)
+    }
+
+    def "should pin locked pair and auto-staff only the remaining matches"() {
+        given:
+        short queue = 3
+        def team1 = Team.builder().name("team A").build()
+        def team2 = Team.builder().name("team B").build()
+        def lockedReferee = Referee.builder().id(11l).firstName("Locked").lastName("Referee").build()
+        def freeReferee = Referee.builder().id(22l).averageGrade(8.0d).teamsRefereed([:]).numberOfMatchesInRound((short) 0).build()
+        def lockedMatch = Match.builder().id(1l).home(team1).away(team2).build()
+        def otherMatch = Match.builder().id(2l).home(team2).away(team1).build()
+        def locks = [new StaffingLockRequest(1l, 11l)]
+
+        when:
+        stafferService.staffReferees(queue, locks)
+
+        then:
+        lockedMatch.referee == lockedReferee
+        otherMatch.referee == freeReferee
+        1 * matchService.getMatchesToAssignInQueue(queue) >> [lockedMatch, otherMatch]
+        1 * refereeRepository.findById(11l) >> Optional.of(lockedReferee)
+        // Pinned state must be flushed before the native availability query runs.
+        1 * matchRepository.flush()
+        // The pool already excludes the locked referee — only the auto-staffed match draws from it.
+        1 * refereeService.getAvailableRefereesForQueue(queue) >> [freeReferee]
+        1 * refereeService.calculateStats([freeReferee])
+        1 * vacationRepository.findAllByStartDateIsLessThanEqualAndEndDateIsGreaterThanEqual(_) >> []
+        1 * matchConverter.convertFromEntities([lockedMatch, otherMatch])
+        1 * configurationRepository.findAllAsMap() >> allOnesConfig()
+    }
+
+    def "should clear stale assignment and re-staff the match on regenerate"() {
+        given:
+        short queue = 3
+        def staleReferee = Referee.builder().id(1l).firstName("Stale").lastName("Assignment").build()
+        def newReferee = Referee.builder().id(2l).averageGrade(8.0d).teamsRefereed([:]).numberOfMatchesInRound((short) 0).build()
+        def match = Match.builder()
+                .id(5l)
+                .home(Team.builder().name("home").build())
+                .away(Team.builder().name("away").build())
+                .referee(staleReferee)
+                .build()
+
+        when:
+        stafferService.staffReferees(queue)
+
+        then:
+        match.referee == newReferee
+        1 * matchService.getMatchesToAssignInQueue(queue) >> [match]
+        1 * matchRepository.flush()
+        1 * refereeService.getAvailableRefereesForQueue(queue) >> [newReferee]
+        1 * vacationRepository.findAllByStartDateIsLessThanEqualAndEndDateIsGreaterThanEqual(_) >> []
+        1 * matchConverter.convertFromEntities([match])
+        1 * configurationRepository.findAllAsMap() >> allOnesConfig()
+    }
+
+    def "should reject lock referencing a match that is not assignable in the queue"() {
+        given:
+        short queue = 4
+        def assignableMatch = Match.builder().id(1l).build()
+        def locks = [new StaffingLockRequest(99l, 11l)]
+
+        when:
+        stafferService.staffReferees(queue, locks)
+
+        then:
+        1 * matchService.getMatchesToAssignInQueue(queue) >> [assignableMatch]
+        0 * refereeRepository.findById(_)
+        0 * refereeService.getAvailableRefereesForQueue(_)
+        def exception = thrown(StafferException)
+        exception.message == String.format(StafferService.LOCKED_MATCH_NOT_ASSIGNABLE, 99l, queue)
+        assignableMatch.referee == null
+    }
+
+    def "should reject duplicate locks"() {
+        given:
+        short queue = 4
+        def matches = [Match.builder().id(1l).build(), Match.builder().id(2l).build()]
+
+        when:
+        stafferService.staffReferees(queue, locks)
+
+        then:
+        1 * matchService.getMatchesToAssignInQueue(queue) >> matches
+        0 * refereeRepository.findById(_)
+        def exception = thrown(StafferException)
+        exception.message == expectedMessage
+
+        where:
+        locks                                                              | expectedMessage
+        [new StaffingLockRequest(1l, 11l), new StaffingLockRequest(1l, 12l)] | String.format(StafferService.DUPLICATE_LOCKED_MATCH, 1l)
+        [new StaffingLockRequest(1l, 11l), new StaffingLockRequest(2l, 11l)] | String.format(StafferService.DUPLICATE_LOCKED_REFEREE, 11l)
+    }
+
+    def "should throw RefereeNotFoundException when locked referee does not exist"() {
+        given:
+        short queue = 4
+        def match = Match.builder().id(1l).build()
+        def locks = [new StaffingLockRequest(1l, 77l)]
+
+        when:
+        stafferService.staffReferees(queue, locks)
+
+        then:
+        1 * matchService.getMatchesToAssignInQueue(queue) >> [match]
+        1 * refereeRepository.findById(77l) >> Optional.empty()
+        0 * refereeService.getAvailableRefereesForQueue(_)
+        thrown(RefereeNotFoundException)
+    }
+
+    private static Map<ConfigName, Double> allOnesConfig() {
+        [
+                (ConfigName.AVERAGE_GRADE_MULTIPLIER)     : 1.0d,
+                (ConfigName.EXPERIENCE_MULTIPLIER)        : 1.0d,
+                (ConfigName.NUMBER_OF_MATCHES_MULTIPLIER) : 1.0d,
+                (ConfigName.HOME_TEAM_REFEREED_MULTIPLIER): 1.0d,
+                (ConfigName.AWAY_TEAM_REFEREED_MULTIPLIER): 1.0d
+        ]
     }
 }


### PR DESCRIPTION
## Ticket

[RS-73: Lock-aware regenerate — staffReferees(queue, locks)](https://referee-staffer.youtrack.cloud/issue/RS-73)

The Staffer screen lets the user lock (pin) match–referee pairs, but the locks lived only in the UI: `POST /api/staffer/{queue}` knew nothing about them, so a regenerate could overwrite a pinned referee and the frontend had to restore locks after the fact (open TODO in `StafferComponent`). The ticket asks the endpoint to accept a list of pre-pinned `(matchId, refereeId)` pairs and treat them as taken — referee busy, match cast — while the algorithm staffs the rest.

## Plan

Analysis done before touching the code:

1. **Root problem is wider than the missing request body.** `staffReferees` is `@Transactional` and mutates managed entities, so assignments persist the moment a cast is generated (proven by `StafferIntegrationSpec`). The match query used `findAllByQueueAndRefereeIsNull`, so a second "Generate cast" found *nothing* to staff — regenerate returned an empty cast and could never reshuffle anything. Lock-aware regenerate therefore needs the backend to *reclaim* previously auto-assigned matches, not just accept locks.
2. **Redefine "matches to assign"** in `MatchService`: all matches of the queue except those that must keep their referee — central "S C" assignments and finished matches (both scores present). Unassigned matches stay included as before.
3. **Centralize the "S C" sentinel** check (`Referee.isCentralSentinel()`) instead of duplicating the magic name — the full flag-on-Match remodel suggested by the ticket is left as a follow-up.
4. **`StafferService.staffReferees(queue, locks)`**: validate locks → clear stale assignments → pin locked pairs → flush (the availability query is native SQL and only sees flushed state) → build the pool with the existing `getAvailableRefereesForQueue` (freed referees return, locked/kept ones drop out) → greedy-staff only the still-unassigned matches → return the whole assignable set sorted by difficulty.
5. **Controller**: optional `@RequestBody List<StaffingLockRequest>`; no body = plain regenerate, so existing clients keep working.
6. **Frontend**: send the lock map with the staffing request, clear locks on queue change (they reference matches of the previous queue), update the copy that said locks are "not yet preserved on regenerate".
7. **Tests**: Spock unit specs for pinning, re-staffing, and validation; integration specs proving lock survival and central-assignment immunity against real H2; controller spec for body parsing; Karma specs for the new frontend behavior.

Risks identified up front: semantic change of `getMatchesToAssignInQueue` (previously assigned, unfinished, non-central matches are now regenerated — that *is* the feature, and locking is the way to keep an assignment); locks deliberately bypass the vacation filter (an explicit user pin wins).

## Changes

- **`StafferController`** — `POST /api/staffer/{queue}` accepts an optional JSON array of `{matchId, refereeId}` locks (`StaffingLockRequest` record; `null` body → empty list).
- **`MatchService.getMatchesToAssignInQueue`** — now `findAllByQueue` + `isAssignable` filter: unassigned matches always; assigned ones unless central ("S C") or finished. `findAllByQueueAndRefereeIsNull` removed.
- **`Referee.isCentralSentinel()`** — single home for the "S C" magic-name check, reused in `RefereeService`.
- **`StafferService`** — lock validation (409 `StafferException` for non-assignable/duplicate locks, 404 `RefereeNotFoundException` for an unknown referee — all before any mutation), stale-assignment clearing, pinning, explicit `flush()` before the native availability query, auto-staffing restricted to still-unassigned matches. Returned cast includes the locked matches with their difficulty, sorted as before.
- **Transactionality fix** — the 1-arg `staffReferees` overload delegates via self-invocation, which bypasses the Spring proxy; it now carries its own `@Transactional`, otherwise assignments were never flushed (caught by the integration spec during development).
- **Frontend** — `StafferService.staffReferees(queue, locks)` posts the lock list; `StafferComponent.generate()` serializes the `locks` signal; `incQueue`/`decQueue` clear locks; comments and the "Locked assignments" KPI copy updated. New `StaffingLock` model interface.

Design decisions: validation errors reuse `StafferException` → existing 409 + ProblemDetail mapping (a lock conflict is a business-state conflict, not a malformed request); a failed staffing rolls the whole transaction back, so the previous cast survives; on error the toast comes from the existing global HTTP interceptor — no new UI needed.

## Testing

- Backend: `mvn -DskipFrontend=true test` — **141 tests green** (ran on OpenJDK 25). New: 5 unit features in `StafferServiceSpec` (pin + auto-staff split, stale-assignment clearing, non-assignable lock, duplicate lock pairs, unknown referee), 1 in `MatchServiceSpec` (assignability filter incl. central/finished), 1 in `StafferControllerSpec` (body → service parsing), 2 integration features in `StafferIntegrationSpec` (locked pair survives a regenerate and the rest is re-staffed from the remaining pool; central assignments untouched and excluded from the returned cast).
- Frontend: `npm ci`, `npm run lint` (clean), `npm test` headless — **139 tests green**. New: locks are sent on regenerate; queue change clears locks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HRnbstWjY9J8HvNUDw8AoR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRnbstWjY9J8HvNUDw8AoR)_