### PR TITLE
RS-74: Make Team.place a nullable Short instead of magic 0

### DIFF
--- a/src/main/java/com/jamex/refereestaffer/model/converter/TeamConverter.java
+++ b/src/main/java/com/jamex/refereestaffer/model/converter/TeamConverter.java
@@ -18,6 +18,6 @@ public class TeamConverter implements BaseConverter<Team, TeamDto> {
         // shortCode is deliberately not taken from the DTO: `short` in JSON is a computed
         // read-model field (GET fills it with the name-derived fallback), so echoing it
         // back on writes would persist the fallback as a stored override.
-        return new Team(dto.id(), dto.name(), dto.city(), null, (short) 0, (short) 0);
+        return new Team(dto.id(), dto.name(), dto.city(), null, (short) 0, null);
     }
 }

--- a/src/main/java/com/jamex/refereestaffer/model/entity/Team.java
+++ b/src/main/java/com/jamex/refereestaffer/model/entity/Team.java
@@ -32,17 +32,22 @@ public class Team {
     @Transient
     private short points;
 
+    /**
+     * Standings position computed by {@code MatchService.calculatePointsForTeams} — only
+     * teams that appear in a finished match get ranked. {@code null} means unranked (no
+     * finished matches yet); never 0.
+     */
     @Transient
-    private short place;
+    private Short place;
 
     public Team() {
     }
 
-    public Team(Long id, String name, String city, short points, short place) {
+    public Team(Long id, String name, String city, short points, Short place) {
         this(id, name, city, null, points, place);
     }
 
-    public Team(Long id, String name, String city, String shortCode, short points, short place) {
+    public Team(Long id, String name, String city, String shortCode, short points, Short place) {
         this.id = id;
         this.name = name;
         this.city = city;
@@ -104,11 +109,11 @@ public class Team {
         return points;
     }
 
-    public short getPlace() {
+    public Short getPlace() {
         return place;
     }
 
-    public void setPlace(short place) {
+    public void setPlace(Short place) {
         this.place = place;
     }
 
@@ -135,7 +140,7 @@ public class Team {
         private String city;
         private String shortCode;
         private short points;
-        private short place;
+        private Short place;
 
         public Builder id(Long id) {
             this.id = id;
@@ -162,7 +167,7 @@ public class Team {
             return this;
         }
 
-        public Builder place(short place) {
+        public Builder place(Short place) {
             this.place = place;
             return this;
         }

--- a/src/main/java/com/jamex/refereestaffer/service/MatchService.java
+++ b/src/main/java/com/jamex/refereestaffer/service/MatchService.java
@@ -138,11 +138,10 @@ public class MatchService {
 
     /** Returns [top, bottom] — at most one of them can be non-zero. */
     private double[] computeEdgeMatchParts(Team homeTeam, Team awayTeam, Map<ConfigName, Double> config, long numberOfTeams) {
-        // place is a @Transient field defaulting to 0 for any team that hasn't appeared in
-        // a finished match yet (calculatePointsForTeams only ranks teams from the finished set).
-        // Without this guard, place=0 satisfies `place <= numberOfTeamsOnEdge` (0 <= 3 by default),
-        // so a fresh team's match would be classified as a top-of-table fixture by accident.
-        if (homeTeam.getPlace() == 0 || awayTeam.getPlace() == 0) {
+        // place is null for any team that hasn't appeared in a finished match yet
+        // (calculatePointsForTeams only ranks teams from the finished set), so an unranked
+        // team can never be classified as a top- or bottom-of-table fixture.
+        if (homeTeam.getPlace() == null || awayTeam.getPlace() == null) {
             return new double[]{0.0, 0.0};
         }
         var numberOfTeamsOnEdge = config.get(ConfigName.NUMBER_OF_EDGE_TEAMS).longValue();

--- a/src/test/groovy/com/jamex/refereestaffer/model/converter/TeamConverterSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/model/converter/TeamConverterSpec.groovy
@@ -62,5 +62,8 @@ class TeamConverterSpec extends Specification {
         result.city == teamDto.city
         and: "the entity falls back to the name prefix, proving nothing was stored"
         result.shortCode == "KOR"
+
+        and: "the entity starts unranked until standings are computed"
+        result.place == null
     }
 }

--- a/src/test/groovy/com/jamex/refereestaffer/service/MatchServiceSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/service/MatchServiceSpec.groovy
@@ -113,9 +113,9 @@ class MatchServiceSpec extends Specification {
 
         where:
         homePoints | homePlace | awayPoints | awayPlace
-        0          | 0         | 0          | 0
-        0          | 0         | 30         | 1
-        30         | 1         | 0          | 0
+        0          | null      | 0          | null
+        0          | null      | 30         | 1
+        30         | 1         | 0          | null
     }
 
     def "should get matches to assign for given queue and set hardness level FULL"() {
@@ -263,9 +263,9 @@ class MatchServiceSpec extends Specification {
 
         where:
         homePoints | homePlace | awayPoints | awayPlace
-        0          | 0         | 0          | 0
-        0          | 0         | 30         | 1
-        30         | 1         | 0          | 0
+        0          | null      | 0          | null
+        0          | null      | 30         | 1
+        30         | 1         | 0          | null
     }
 
     def "should refresh standings from finished matches before computing breakdown"() {


### PR DESCRIPTION
## Ticket

[RS-74: Team.place → Short (nullable) zamiast magic 0](https://referee-staffer.youtrack.cloud/issue/RS-74)

`Team.place` was a `@Transient` primitive `short` defaulting to `0` for teams that have no finished matches yet — a magic value. The defensive guard added to `MatchService.calculateHardnessLvlForEdgeMatch` (now `computeEdgeMatchParts`) special-cased `place == 0` so a fresh team's match would not accidentally be classified as a top-of-table fixture (`0 <= NUMBER_OF_EDGE_TEAMS`). That guard masked the modelling problem instead of fixing it. The ticket asks for the minimal fix: make `place` a nullable `Short` where `null` explicitly means "unranked".

## Plan

1. `Team.java`: change `@Transient short place` to `Short place` (null = unranked, never 0); update both constructors, getter/setter, and the nested `Builder`; document the semantics on the field.
2. `TeamConverter.convertFromDto`: build entities with `null` place instead of `(short) 0`.
3. `MatchService.computeEdgeMatchParts`: replace the `place == 0` guard with `place == null` and rewrite the comment to describe the new semantics.
4. `MatchServiceSpec`: represent unranked teams as `place: null` (previously `place: 0`) in both "unranked" data tables; add a converter spec assertion that a freshly converted entity is unranked.
5. Run `mvn -DskipFrontend=true test`.

Scope note: `TeamDto` never exposed `place`, so the REST contract and the Angular frontend are untouched. The ticket's further-reaching variant (moving `place`/`points` off the entity into a standings query) is explicitly left for RS-27.

## Changes

- `Team.java` — `place` is now `Short` with `null` meaning unranked; constructors, accessors, and `Builder` updated; javadoc added on the field. `points` intentionally stays a primitive `short` (0 points is a legitimate value, unlike place 0).
- `TeamConverter.java` — `convertFromDto` no longer fabricates `place = 0`; converted entities start unranked.
- `MatchService.java` — the edge-match guard checks `getPlace() == null`. `calculatePointsForTeams` still calls `setPlace((short) (i + 1))`, which now autoboxes; ranked places remain 1-based. The `place <= edge` / `place > teams - edge` comparisons unbox only after the null guard, so no NPE is possible.
- `MatchServiceSpec.groovy` — unranked rows in the two data tables use `null` instead of `0`, matching the new semantics; ranked rows unchanged.
- `TeamConverterSpec.groovy` — asserts `result.place == null` for DTO → entity conversion.

Also unchanged on purpose: `TeamService.getStandings` appends teams without matches to the standings list — those now carry `place = null` instead of `0`, but since `place` never leaves the backend, nothing downstream observes the difference.

## Testing

- `mvn -DskipFrontend=true test` — all 145 Spock tests pass.
- Coverage unchanged at 91.55% (Codecov); the changed lines are all covered, including the two parameterized "unranked" features (6 iterations) that pin the guard behaviour and the new converter assertion.
- No frontend changes, so the frontend workflow is not triggered (`paths` filter on `src/main/webapp/**`).

### Rebase note

Rebased onto master after #99 (DTOs → records) and the Java 26 bump landed. One conflict, in `TeamConverter.convertFromDto`: master switched the DTO reads to record accessors (`dto.id()`), this branch changed the trailing `place` argument to `null`. Resolved by keeping both — `new Team(dto.id(), dto.name(), dto.city(), null, (short) 0, null)`. Post-rebase suite is the 145 above (master's #99 added specs).

🤖 Generated with Claude Code