### PR TITLE
RS-75: Disable spring.jpa.open-in-view

### DIFF
--- a/src/main/java/com/jamex/refereestaffer/service/MatchService.java
+++ b/src/main/java/com/jamex/refereestaffer/service/MatchService.java
@@ -14,6 +14,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -40,26 +42,86 @@ public class MatchService {
         this.teamRepository = teamRepository;
     }
 
-    public void calculatePointsForTeams(List<Match> matches) {
+    /**
+     * Points and table places keyed by team id, for the teams that appear in the finished
+     * matches a ranking pass was built from.
+     *
+     * <p>Keyed by id rather than by entity on purpose: with {@code open-in-view: false} the
+     * match being scored and the matches the table was computed from can come from different
+     * persistence contexts, so the {@code Team} instances are different objects and
+     * {@code Team} has no {@code equals}/{@code hashCode}. Reading the numbers off the entity
+     * would then silently yield the un-enriched values (0 points, no place) — see RS-75.
+     *
+     * <p>Teams absent from the ranking (no finished match yet) report 0 points and a
+     * {@code null} place, matching what a freshly loaded entity used to carry.
+     */
+    public record LeagueTable(Map<Long, Short> pointsByTeamId, Map<Long, Short> placeByTeamId) {
+
+        public short pointsOf(Team team) {
+            return pointsByTeamId.getOrDefault(team.getId(), (short) 0);
+        }
+
+        public Short placeOf(Team team) {
+            return placeByTeamId.get(team.getId());
+        }
+    }
+
+    /**
+     * Ranks the teams taking part in {@code matches} and returns the resulting table.
+     *
+     * <p>Ranking rules are unchanged from when this method only mutated entities: only teams
+     * with a finished match are ranked, ordering is by points alone, and ties keep the order
+     * in which the teams were first encountered. Replacing them with the richer tie-break
+     * chain of {@link TeamService#getStandings} would move matches between table zones and
+     * therefore change match hardness — that unification is RS-99, deliberately not this
+     * change.
+     *
+     * <p>The transient {@code points}/{@code place} fields are still written to the entities
+     * for the benefit of callers that read them off {@code Team}; the returned table is the
+     * authoritative, session-independent copy. Dropping the entity mutation altogether is
+     * likewise RS-99.
+     */
+    public LeagueTable calculatePointsForTeams(List<Match> matches) {
+        // Insertion-ordered so that the sort below — which is stable — leaves teams on equal
+        // points in first-encountered order, exactly as the previous stream pipeline did.
+        var pointsByTeamId = new LinkedHashMap<Long, Short>();
         for (var match : matches) {
+            var home = match.getHome();
+            var away = match.getAway();
+            pointsByTeamId.putIfAbsent(home.getId(), (short) 0);
+            pointsByTeamId.putIfAbsent(away.getId(), (short) 0);
+
             if (match.getHomeScore() > match.getAwayScore())
-                match.getHome().addPoints(POINTS_FOR_WIN_MATCH);
+                award(pointsByTeamId, home, POINTS_FOR_WIN_MATCH);
             else if (match.getHomeScore() < match.getAwayScore())
-                match.getAway().addPoints(POINTS_FOR_WIN_MATCH);
+                award(pointsByTeamId, away, POINTS_FOR_WIN_MATCH);
             else {
-                match.getHome().addPoints(POINTS_FOR_DRAW_MATCH);
-                match.getAway().addPoints(POINTS_FOR_DRAW_MATCH);
+                award(pointsByTeamId, home, POINTS_FOR_DRAW_MATCH);
+                award(pointsByTeamId, away, POINTS_FOR_DRAW_MATCH);
             }
         }
-        // TODO extract to separate method. Maybe refactor this place
-        var teams = matches.stream()
+
+        var rankedTeamIds = pointsByTeamId.entrySet().stream()
+                .sorted(Map.Entry.<Long, Short>comparingByValue().reversed())
+                .map(Map.Entry::getKey)
+                .toList();
+        var placeByTeamId = new HashMap<Long, Short>();
+        IntStream.range(0, rankedTeamIds.size())
+                .forEach(i -> placeByTeamId.put(rankedTeamIds.get(i), (short) (i + 1)));
+
+        var table = new LeagueTable(pointsByTeamId, placeByTeamId);
+        matches.stream()
                 .flatMap(match -> Stream.of(match.getHome(), match.getAway()))
                 .distinct()
-                .sorted(Comparator.comparingInt(Team::getPoints).reversed())
-                .toList();
+                .forEach(team -> {
+                    team.addPoints(table.pointsOf(team));
+                    team.setPlace(table.placeOf(team));
+                });
+        return table;
+    }
 
-        IntStream.range(0, teams.size())
-                .forEach(i -> teams.get(i).setPlace((short) (i + 1)));
+    private static void award(Map<Long, Short> pointsByTeamId, Team team, short points) {
+        pointsByTeamId.merge(team.getId(), points, (a, b) -> (short) (a + b));
     }
 
     public void deleteMatch(Long matchId) {
@@ -74,7 +136,7 @@ public class MatchService {
 
     public List<Match> getMatchesToAssignInQueue(Short queue) {
         var allFinishedMatches = matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull();
-        calculatePointsForTeams(allFinishedMatches);
+        var table = calculatePointsForTeams(allFinishedMatches);
 
         var matchesToAssignInQueue = matchRepository.findAllByQueueAndRefereeIsNull(queue);
 
@@ -82,7 +144,7 @@ public class MatchService {
         // once here instead of per match (used to be 4-5 findByName + count per iteration).
         var config = configurationRepository.findAllAsMap();
         var numberOfTeams = teamRepository.count();
-        matchesToAssignInQueue.forEach(match -> match.setHardnessLvl(computeBreakdown(match, config, numberOfTeams).total()));
+        matchesToAssignInQueue.forEach(match -> match.setHardnessLvl(computeBreakdown(match, table, config, numberOfTeams).total()));
         return matchesToAssignInQueue.stream()
                 .sorted(Comparator.comparingDouble(Match::getHardnessLvl).reversed())
                 .toList();
@@ -92,6 +154,11 @@ public class MatchService {
      * Public entry-point for the redesigned Staffer drawer + Match detail screens. Loads
      * the match (404 if missing), then recomputes points/places against the latest finished
      * matches so `place` is fresh, and returns the per-component breakdown.
+     *
+     * <p>Note the match and the table come from two separate repository calls, and with
+     * {@code open-in-view: false} nothing keeps them in one persistence context — hence the
+     * scoring below reads the numbers out of the returned {@link LeagueTable} rather than
+     * off {@code match.getHome()}, whose transient fields belong to the other session.
      */
     public DifficultyBreakdownDto computeDifficultyBreakdown(Long matchId) {
         var match = matchRepository.findById(matchId)
@@ -100,24 +167,31 @@ public class MatchService {
         // Refresh standings so place-based bonuses are computed against current data — same
         // pattern getMatchesToAssignInQueue uses before scoring.
         var finishedMatches = matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull();
-        calculatePointsForTeams(finishedMatches);
+        var table = calculatePointsForTeams(finishedMatches);
 
-        return computeBreakdown(match, configurationRepository.findAllAsMap(), teamRepository.count());
+        return computeBreakdown(match, table, configurationRepository.findAllAsMap(), teamRepository.count());
     }
 
-    private DifficultyBreakdownDto computeBreakdown(Match match, Map<ConfigName, Double> config, long numberOfTeams) {
+    /**
+     * Scores a single match against an already-computed table. Package-private so specs can
+     * exercise the zone/derby permutations with an explicit {@link LeagueTable} instead of
+     * fabricating transient state on {@code Team} entities — a state production never
+     * produces, since those fields are only ever written by a ranking pass.
+     */
+    DifficultyBreakdownDto computeBreakdown(Match match, LeagueTable table,
+                                            Map<ConfigName, Double> config, long numberOfTeams) {
         var matchHardnessLvlMultiplier = config.get(ConfigName.DIFFICULTY_LEVEL_MULTIPLIER);
         var matchHardnessIncrementer = config.get(ConfigName.DIFFICULTY_LEVEL_INCREMENTER);
         var homeTeam = match.getHome();
         var awayTeam = match.getAway();
-        var pointsDiff = Math.abs(homeTeam.getPoints() - awayTeam.getPoints());
+        var pointsDiff = Math.abs(table.pointsOf(homeTeam) - table.pointsOf(awayTeam));
 
         var base = (matchHardnessIncrementer - pointsDiff) * matchHardnessLvlMultiplier;
         var sameCity = isDerby(homeTeam, awayTeam)
                 ? config.get(ConfigName.DIFFICULTY_LEVEL_SAME_CITY_INCREMENTER)
                 : 0.0;
 
-        var topAndBottom = computeEdgeMatchParts(homeTeam, awayTeam, config, numberOfTeams);
+        var topAndBottom = computeEdgeMatchParts(homeTeam, awayTeam, table, config, numberOfTeams);
         var top = topAndBottom[0];
         var bottom = topAndBottom[1];
 
@@ -137,18 +211,21 @@ public class MatchService {
     }
 
     /** Returns [top, bottom] — at most one of them can be non-zero. */
-    private double[] computeEdgeMatchParts(Team homeTeam, Team awayTeam, Map<ConfigName, Double> config, long numberOfTeams) {
+    private double[] computeEdgeMatchParts(Team homeTeam, Team awayTeam, LeagueTable table,
+                                           Map<ConfigName, Double> config, long numberOfTeams) {
         // place is null for any team that hasn't appeared in a finished match yet
         // (calculatePointsForTeams only ranks teams from the finished set), so an unranked
         // team can never be classified as a top- or bottom-of-table fixture.
-        if (homeTeam.getPlace() == null || awayTeam.getPlace() == null) {
+        var homePlace = table.placeOf(homeTeam);
+        var awayPlace = table.placeOf(awayTeam);
+        if (homePlace == null || awayPlace == null) {
             return new double[]{0.0, 0.0};
         }
         var numberOfTeamsOnEdge = config.get(ConfigName.NUMBER_OF_EDGE_TEAMS).longValue();
-        if (homeTeam.getPlace() <= numberOfTeamsOnEdge && awayTeam.getPlace() <= numberOfTeamsOnEdge) {
+        if (homePlace <= numberOfTeamsOnEdge && awayPlace <= numberOfTeamsOnEdge) {
             return new double[]{config.get(ConfigName.DIFFICULTY_LEVEL_MATCH_ON_TOP_INCREMENTER), 0.0};
         }
-        if (homeTeam.getPlace() > numberOfTeams - numberOfTeamsOnEdge && awayTeam.getPlace() > numberOfTeams - numberOfTeamsOnEdge) {
+        if (homePlace > numberOfTeams - numberOfTeamsOnEdge && awayPlace > numberOfTeams - numberOfTeamsOnEdge) {
             return new double[]{0.0, config.get(ConfigName.DIFFICULTY_LEVEL_MATCH_ON_BOTTOM_INCREMENTER)};
         }
         return new double[]{0.0, 0.0};

--- a/src/main/java/com/jamex/refereestaffer/service/RefereeService.java
+++ b/src/main/java/com/jamex/refereestaffer/service/RefereeService.java
@@ -54,13 +54,15 @@ public class RefereeService {
             return;
         }
         // One bulk query instead of a findAllByReferee per referee (N+1 — this runs on every
-        // referee list/profile GET, not just staffing). Grouping by the entity works because
-        // Hibernate returns the same managed Referee instances that went into the IN clause.
-        var matchesByReferee = matchRepository.findAllByRefereeIn(referees).stream()
-                .collect(Collectors.groupingBy(Match::getReferee));
+        // referee list/profile GET, not just staffing). Group by id, not by entity: with OSIV
+        // off, the referees passed in by a controller come from a different (already closed)
+        // session than this query, so Hibernate returns different instances — and Referee
+        // compares by identity, which would make every lookup below miss.
+        var matchesByRefereeId = matchRepository.findAllByRefereeIn(referees).stream()
+                .collect(Collectors.groupingBy(match -> match.getReferee().getId()));
 
         for (var referee : referees) {
-            var matchesForReferee = matchesByReferee.getOrDefault(referee, List.of());
+            var matchesForReferee = matchesByRefereeId.getOrDefault(referee.getId(), List.of());
 
             var averageGrade = countAverageGrade(matchesForReferee);
             var teamsRefereedMap = createTeamsRefereedMap(matchesForReferee);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,10 @@ spring:
   datasource:
     url: jdbc:h2:mem:testdb;MODE=MySQL;NON_KEYWORDS=VALUE
   jpa:
+    # Session-per-request (OSIV) masks lazy-loading problems and holds the Hibernate
+    # session open for the whole HTTP request. The only lazy association in the model
+    # (Referee.matches) is never traversed, so nothing relies on it — see RS-75.
+    open-in-view: false
     defer-datasource-initialization: true
     hibernate:
       ddl-auto: update

--- a/src/test/groovy/com/jamex/refereestaffer/integration/OpenInViewDisabledIntegrationSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/integration/OpenInViewDisabledIntegrationSpec.groovy
@@ -1,0 +1,153 @@
+package com.jamex.refereestaffer.integration
+
+import com.jamex.refereestaffer.model.entity.Grade
+import com.jamex.refereestaffer.model.entity.Match
+import com.jamex.refereestaffer.model.entity.Referee
+import com.jamex.refereestaffer.model.entity.Team
+import com.jamex.refereestaffer.model.entity.Vacation
+import com.jamex.refereestaffer.repository.GradeRepository
+import com.jamex.refereestaffer.repository.MatchRepository
+import com.jamex.refereestaffer.repository.RefereeRepository
+import com.jamex.refereestaffer.repository.TeamRepository
+import com.jamex.refereestaffer.repository.VacationRepository
+import groovy.json.JsonSlurper
+import org.spockframework.runtime.model.parallel.ExecutionMode
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.core.env.Environment
+import org.springframework.test.web.servlet.MockMvc
+import spock.lang.Execution
+import spock.lang.Isolated
+import spock.lang.Specification
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+
+/**
+ * Regression net for disabling OSIV ({@code spring.jpa.open-in-view: false}, RS-75).
+ * The controller slices mock repositories away, so they can never catch a
+ * LazyInitializationException — this spec drives full HTTP requests (controller →
+ * converter/service → real repositories → H2 → JSON serialisation) with no
+ * session-per-request to lean on. If someone reintroduces a lazy traversal outside a
+ * transaction, these requests are where it blows up.
+ *
+ * {@code @Isolated} because it shares the H2 instance with other integration specs
+ * (parallel Spock run) and both sides wipe/seed domain tables in setup. {@code @Isolated}
+ * only fences off OTHER specs — features of this spec would still run concurrently and
+ * wipe each other's seed data, hence {@code SAME_THREAD} on top.
+ */
+@Isolated
+@Execution(ExecutionMode.SAME_THREAD)
+@AutoConfigureMockMvc
+@SpringBootTest
+class OpenInViewDisabledIntegrationSpec extends Specification {
+
+    @Autowired MockMvc mockMvc
+    @Autowired Environment environment
+    @Autowired TeamRepository teamRepository
+    @Autowired RefereeRepository refereeRepository
+    @Autowired MatchRepository matchRepository
+    @Autowired GradeRepository gradeRepository
+    @Autowired VacationRepository vacationRepository
+
+    def jsonSlurper = new JsonSlurper()
+
+    Long matchId
+    Long refereeId
+
+    def setup() {
+        wipeDomainData()
+
+        def home = teamRepository.save(new Team("Team1", "City1"))
+        def away = teamRepository.save(new Team("Team2", "City2"))
+        def referee = refereeRepository.save(new Referee("John", "Doe", "john@doe.com", 5))
+        short queue = 1
+        def match = matchRepository.save(new Match(queue, home, away,
+                LocalDateTime.of(2026, 3, 1, 12, 0), referee, (short) 2, (short) 1))
+        gradeRepository.save(Grade.builder().value(8.5d).match(match).build())
+        vacationRepository.save(new Vacation(null, referee,
+                LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 14)))
+
+        matchId = match.id
+        refereeId = referee.id
+    }
+
+    def "should have OSIV disabled"() {
+        expect:
+        environment.getProperty("spring.jpa.open-in-view") == "false"
+    }
+
+    def "should serve a match with all relations resolved without OSIV"() {
+        when:
+        def response = mockMvc.perform(get("/api/matches/$matchId"))
+                .andReturn().response
+
+        then:
+        response.status == 200
+        // No with() here: bare property names inside with(parsedJson) resolve against the
+        // JSON delegate before spec fields, silently comparing the JSON to itself.
+        def match = jsonSlurper.parseText(response.contentAsString)
+        match.homeTeamId != null
+        match.awayTeamId != null
+        match.refereeId == refereeId
+        match.gradeId != null
+    }
+
+    def "should serve referees enriched with stats without OSIV"() {
+        when:
+        // enrichWithStats walks match → grade / home / away for every referee
+        def response = mockMvc.perform(get("/api/referees"))
+                .andReturn().response
+
+        then:
+        response.status == 200
+        def referees = jsonSlurper.parseText(response.contentAsString)
+        referees.size() == 1
+        referees[0].averageGrade == 8.5d
+        referees[0].potential != null
+    }
+
+    def "should serve standings computed from matches without OSIV"() {
+        when:
+        def response = mockMvc.perform(get("/api/teams/standings"))
+                .andReturn().response
+
+        then:
+        response.status == 200
+        def standings = jsonSlurper.parseText(response.contentAsString)
+        standings.size() == 2
+        standings[0].name == "Team1" // 2:1 home win → Team1 on top
+    }
+
+    def "should serve vacations with their referee resolved without OSIV"() {
+        when:
+        def response = mockMvc.perform(get("/api/vacations"))
+                .andReturn().response
+
+        then:
+        response.status == 200
+        def vacations = jsonSlurper.parseText(response.contentAsString)
+        vacations.size() == 1
+        vacations[0].refereeId == refereeId
+    }
+
+    def cleanup() {
+        // Leave only the data.sql config rows behind for whoever shares the H2 instance.
+        wipeDomainData()
+    }
+
+    private void wipeDomainData() {
+        // FK order: grade → match, match → team/referee, vacation → referee. Batch variants
+        // issue plain DELETEs without loading entities — deleteAll() would pull each Grade
+        // (and, through the EAGER one-to-one, its Match pointing back at the doomed Grade)
+        // into the session and fail the flush-time transient-reference check.
+        gradeRepository.deleteAllInBatch()
+        vacationRepository.deleteAllInBatch()
+        matchRepository.deleteAllInBatch()
+        refereeRepository.deleteAllInBatch()
+        teamRepository.deleteAllInBatch()
+    }
+}

--- a/src/test/groovy/com/jamex/refereestaffer/integration/OpenInViewDisabledIntegrationSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/integration/OpenInViewDisabledIntegrationSpec.groovy
@@ -118,8 +118,32 @@ class OpenInViewDisabledIntegrationSpec extends Specification {
         then:
         response.status == 200
         def standings = jsonSlurper.parseText(response.contentAsString)
-        standings.size() == 2
-        standings[0].name == "Team1" // 2:1 home win → Team1 on top
+        standings.rows.size() == 2
+        standings.rows[0].name == "Team1" // 2:1 home win → Team1 on top
+        standings.rows[0].points == 3
+    }
+
+    def "should score match difficulty against the freshly computed table without OSIV"() {
+        when:
+        def response = mockMvc.perform(get("/api/matches/$matchId/difficulty"))
+                .andReturn().response
+
+        then: "the endpoint returns 200 either way — only the numbers reveal the regression"
+        response.status == 200
+        def breakdown = jsonSlurper.parseText(response.contentAsString)
+
+        and: "points come from the ranking pass, not from the match's own (other-session) teams"
+        // Team1 won 2:1 → 3 pts vs 0 pts. Reading the transient fields off match.getHome()
+        // instead of the returned table yields pointsDiff 0 and base 100.0 here, silently,
+        // with no exception to give it away — that is the RS-75 trap this feature guards.
+        breakdown.flags.pointsDiff == 3
+        breakdown.parts.base == 97.0d // (DIFFICULTY_LEVEL_INCREMENTER 100 - 3) * multiplier 1.0
+
+        and: "both teams sit inside the 3-team edge zone, so the top-of-table bonus applies"
+        breakdown.flags.isTop
+        !breakdown.flags.isBot
+        breakdown.parts.top == 7.0d
+        breakdown.total == 104.0d
     }
 
     def "should serve vacations with their referee resolved without OSIV"() {

--- a/src/test/groovy/com/jamex/refereestaffer/service/MatchServiceSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/service/MatchServiceSpec.groovy
@@ -66,18 +66,26 @@ class MatchServiceSpec extends Specification {
 
     def "should calculate points for teams"() {
         given:
-        def team1 = [] as Team
-        def team2 = [] as Team
-        def team3 = [] as Team
+        def team1 = [id: 1L] as Team
+        def team2 = [id: 2L] as Team
+        def team3 = [id: 3L] as Team
         def match1 = [homeScore: 2, awayScore: 0, home: team1, away: team2] as Match
         def match2 = [homeScore: 1, awayScore: 1, home: team3, away: team2] as Match
         def match3 = [homeScore: 2, awayScore: 3, home: team1, away: team3] as Match
         def matches = [match1, match2, match3]
 
         when:
-        matchService.calculatePointsForTeams(matches)
+        def table = matchService.calculatePointsForTeams(matches)
 
-        then:
+        then: "the returned table is keyed by team id"
+        table.pointsOf(team1) == MatchService.POINTS_FOR_WIN_MATCH
+        table.pointsOf(team2) == MatchService.POINTS_FOR_DRAW_MATCH
+        table.pointsOf(team3) == (short) (MatchService.POINTS_FOR_DRAW_MATCH + MatchService.POINTS_FOR_WIN_MATCH)
+        table.placeOf(team1) == (short) 2
+        table.placeOf(team2) == (short) 3
+        table.placeOf(team3) == (short) 1
+
+        and: "the transient entity fields still mirror it — removing them is RS-99"
         team1.points == MatchService.POINTS_FOR_WIN_MATCH
         team2.points == MatchService.POINTS_FOR_DRAW_MATCH
         team3.points == (short) (MatchService.POINTS_FOR_DRAW_MATCH + MatchService.POINTS_FOR_WIN_MATCH)
@@ -86,12 +94,40 @@ class MatchServiceSpec extends Specification {
         team3.place == (short) 1
     }
 
+    def "should rank teams on equal points in the order they were first encountered"() {
+        given: "team2 and team3 both finish on 3 points"
+        def team1 = [id: 1L] as Team
+        def team2 = [id: 2L] as Team
+        def team3 = [id: 3L] as Team
+        def matches = [
+                [homeScore: 0, awayScore: 1, home: team1, away: team2] as Match,
+                [homeScore: 1, awayScore: 0, home: team3, away: team1] as Match
+        ]
+
+        when:
+        def table = matchService.calculatePointsForTeams(matches)
+
+        then: "the tie keeps encounter order — team2 appears before team3 in the match list"
+        table.pointsOf(team2) == table.pointsOf(team3)
+        table.placeOf(team2) == (short) 1
+        table.placeOf(team3) == (short) 2
+        table.placeOf(team1) == (short) 3
+    }
+
     def "should not apply edge-match bonus when at least one team is unranked"() {
-        given:
+        given: "only the winner and loser have played — the other two are absent from the table"
         short queue = 2
-        def homeTeam = [points: homePoints, place: homePlace, city: "city1"] as Team
-        def awayTeam = [points: awayPoints, place: awayPlace, city: "city2"] as Team
-        def matches = [Match.builder().home(homeTeam).away(awayTeam).build()]
+        def winner = [id: 1L, city: "city1"] as Team
+        def loser = [id: 2L, city: "city2"] as Team
+        def unranked = [id: 3L, city: "city3"] as Team
+        def alsoUnranked = [id: 4L, city: "city4"] as Team
+        def finishedMatches = [[homeScore: 2, awayScore: 0, home: winner, away: loser] as Match]
+        // All four cities differ, so no permutation accidentally becomes a derby and reaches
+        // for a same-city incrementer that is deliberately absent from the config below.
+        def matchToAssign = Match.builder()
+                .home(homeIsRanked ? winner : unranked)
+                .away(awayIsRanked ? loser : alsoUnranked)
+                .build()
         def matchHardnessLvlMultiplier = 1.0d
         def matchHardnessIncrementer = 100.0d
 
@@ -99,52 +135,69 @@ class MatchServiceSpec extends Specification {
         def result = matchService.getMatchesToAssignInQueue(queue)
 
         then:
-        def expectedHardness = (matchHardnessIncrementer - Math.abs(awayTeam.points - homeTeam.points)) * matchHardnessLvlMultiplier
-        result.get(0).hardnessLvl == expectedHardness
-        1 * matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull() >> []
-        1 * matchRepository.findAllByQueueAndRefereeIsNull(queue) >> matches
+        1 * matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull() >> finishedMatches
+        1 * matchRepository.findAllByQueueAndRefereeIsNull(queue) >> [matchToAssign]
         // Deliberately no edge/top/bottom keys in the map — the unranked guard must return
         // before those values are ever read (a lookup would NPE and fail the test).
         1 * configurationRepository.findAllAsMap() >> [
                 (ConfigName.DIFFICULTY_LEVEL_MULTIPLIER) : matchHardnessLvlMultiplier,
                 (ConfigName.DIFFICULTY_LEVEL_INCREMENTER): matchHardnessIncrementer
         ]
-        1 * teamRepository.count() >> 3
+        1 * teamRepository.count() >> 4
+
+        and: "only the winner carries points, so the gap is 3 when it is in the fixture"
+        result.get(0).hardnessLvl == (matchHardnessIncrementer - expectedPointsDiff) * matchHardnessLvlMultiplier
 
         where:
-        homePoints | homePlace | awayPoints | awayPlace
-        0          | null      | 0          | null
-        0          | null      | 30         | 1
-        30         | 1         | 0          | null
+        homeIsRanked | awayIsRanked | expectedPointsDiff
+        false        | false        | 0
+        false        | true         | 0
+        true         | false        | MatchService.POINTS_FOR_WIN_MATCH
     }
 
-    def "should get matches to assign for given queue and set hardness level FULL"() {
-        given:
+    def "should get matches to assign for given queue and set hardness level from the computed table"() {
+        given: "team1 beat team2 2:0, so the table reads 3 pts / place 1 against 0 pts / place 2"
         short queue = 2
-        def homeTeam = [points: 10, place: 2, city: "city1"] as Team
-        def awayTeam = [points: 30, place: awayTeamPlace, city: awayTeamCity] as Team
-        def matches = [Match.builder()
-                               .home(homeTeam)
-                               .away(awayTeam)
-                               .build()]
+        def team1 = [id: 1L, city: "city1"] as Team
+        def team2 = [id: 2L, city: "city2"] as Team
+        def finishedMatches = [[homeScore: 2, awayScore: 0, home: team1, away: team2] as Match]
+        def matchToAssign = Match.builder().home(team1).away(team2).build()
         def matchHardnessLvlMultiplier = 2.5d
         def matchHardnessIncrementer = 100.0d
-        def matchHardnessDerbyIncrementer = 15.0d
-        def matchHardnessTopIncrementer = 11.0d
-        def matchHardnessBottomIncrementer = 7.0d
 
         when:
         def result = matchService.getMatchesToAssignInQueue(queue)
 
         then:
-        def expectedHardnessLevel = (matchHardnessIncrementer - Math.abs(awayTeam.points - homeTeam.points)) * matchHardnessLvlMultiplier
-        if (isDerby) expectedHardnessLevel += matchHardnessDerbyIncrementer
-        if (isTopMatch) expectedHardnessLevel += matchHardnessTopIncrementer
-        else if (isBottomMatch) expectedHardnessLevel += matchHardnessBottomIncrementer
-        result.get(0).hardnessLvl == expectedHardnessLevel
-        1 * matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull() >> []
-        1 * matchRepository.findAllByQueueAndRefereeIsNull(queue) >> matches
+        1 * matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull() >> finishedMatches
+        1 * matchRepository.findAllByQueueAndRefereeIsNull(queue) >> [matchToAssign]
         1 * configurationRepository.findAllAsMap() >> [
+                (ConfigName.DIFFICULTY_LEVEL_MULTIPLIER)              : matchHardnessLvlMultiplier,
+                (ConfigName.DIFFICULTY_LEVEL_INCREMENTER)             : matchHardnessIncrementer,
+                (ConfigName.NUMBER_OF_EDGE_TEAMS)                     : 1.0d,
+                (ConfigName.DIFFICULTY_LEVEL_SAME_CITY_INCREMENTER)   : 15.0d,
+                (ConfigName.DIFFICULTY_LEVEL_MATCH_ON_TOP_INCREMENTER): 11.0d,
+                (ConfigName.DIFFICULTY_LEVEL_MATCH_ON_BOTTOM_INCREMENTER): 7.0d
+        ]
+        1 * teamRepository.count() >> 2
+
+        and: "hardness reflects the 3-point gap; the pair straddles the single-team edge zones"
+        result.get(0).hardnessLvl == (matchHardnessIncrementer - MatchService.POINTS_FOR_WIN_MATCH) * matchHardnessLvlMultiplier
+    }
+
+    def "should score the breakdown from the table across derby and edge-zone permutations"() {
+        given:
+        def matchId = 7l
+        def homeTeam = [id: 1L, city: "city1"] as Team
+        def awayTeam = [id: 2L, city: awayTeamCity] as Team
+        def match = Match.builder().id(matchId).home(homeTeam).away(awayTeam).build()
+        def table = leagueTable([(1L): 10, (2L): 30], [(1L): 2, (2L): awayTeamPlace])
+        def matchHardnessLvlMultiplier = 2.5d
+        def matchHardnessIncrementer = 100.0d
+        def matchHardnessDerbyIncrementer = 15.0d
+        def matchHardnessTopIncrementer = 11.0d
+        def matchHardnessBottomIncrementer = 7.0d
+        def config = [
                 (ConfigName.DIFFICULTY_LEVEL_MULTIPLIER)                : matchHardnessLvlMultiplier,
                 (ConfigName.DIFFICULTY_LEVEL_INCREMENTER)               : matchHardnessIncrementer,
                 (ConfigName.NUMBER_OF_EDGE_TEAMS)                       : edgeTeams as Double,
@@ -152,7 +205,28 @@ class MatchServiceSpec extends Specification {
                 (ConfigName.DIFFICULTY_LEVEL_MATCH_ON_TOP_INCREMENTER)  : matchHardnessTopIncrementer,
                 (ConfigName.DIFFICULTY_LEVEL_MATCH_ON_BOTTOM_INCREMENTER): matchHardnessBottomIncrementer
         ]
-        1 * teamRepository.count() >> 3
+
+        when:
+        def result = matchService.computeBreakdown(match, table, config, 3)
+
+        then:
+        result.matchId() == matchId
+        result.parts().base() == (matchHardnessIncrementer - 20) * matchHardnessLvlMultiplier
+        result.parts().sameCity() == (isDerby ? matchHardnessDerbyIncrementer : 0.0d)
+        result.parts().top() == (isTopMatch ? matchHardnessTopIncrementer : 0.0d)
+        result.parts().bottom() == (isBottomMatch ? matchHardnessBottomIncrementer : 0.0d)
+
+        and: "the parts always add up to the total"
+        result.total() == result.parts().base() + result.parts().sameCity() + result.parts().top() + result.parts().bottom()
+
+        and: "top and bottom are mutually exclusive"
+        !(result.parts().top() > 0 && result.parts().bottom() > 0)
+
+        and: "flags mirror the parts"
+        result.flags().sameCity() == isDerby
+        result.flags().isTop() == isTopMatch
+        result.flags().isBot() == isBottomMatch
+        result.flags().pointsDiff() == 20
 
         where:
         awayTeamPlace | awayTeamCity | edgeTeams | isDerby | isTopMatch | isBottomMatch
@@ -177,102 +251,84 @@ class MatchServiceSpec extends Specification {
         exception.message == String.format(MatchNotFoundException.NOT_FOUND, matchId)
     }
 
-    def "should compute difficulty breakdown with parts summing to total"() {
-        given:
+    def "should score the breakdown from the table even when the match carries teams from another persistence context"() {
+        given: "the match and the finished matches return distinct Team instances for the same ids"
         def matchId = 7l
-        def homeTeam = [points: 10, place: 2, city: "city1"] as Team
-        def awayTeam = [points: 30, place: awayTeamPlace, city: awayTeamCity] as Team
-        def match = Match.builder().id(matchId).home(homeTeam).away(awayTeam).build()
-        def matchHardnessLvlMultiplier = 2.5d
+        // What findById returns: never went through a ranking pass, so its transient fields
+        // are still 0 / null. Reading points and place off these instances is exactly the
+        // RS-75 regression — with open-in-view: false this is what production hands us.
+        def staleHome = [id: 1L, city: "city1"] as Team
+        def staleAway = [id: 2L, city: "city2"] as Team
+        def match = Match.builder().id(matchId).home(staleHome).away(staleAway).build()
+
+        def rankedHome = [id: 1L, city: "city1"] as Team
+        def rankedAway = [id: 2L, city: "city2"] as Team
+        def finishedMatches = [[homeScore: 2, awayScore: 0, home: rankedHome, away: rankedAway] as Match]
+        def matchHardnessLvlMultiplier = 2.0d
         def matchHardnessIncrementer = 100.0d
-        def matchHardnessDerbyIncrementer = 15.0d
-        def matchHardnessTopIncrementer = 11.0d
-        def matchHardnessBottomIncrementer = 7.0d
 
         when:
         def result = matchService.computeDifficultyBreakdown(matchId)
 
         then:
         1 * matchRepository.findById(matchId) >> Optional.of(match)
-        1 * matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull() >> []
+        1 * matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull() >> finishedMatches
         1 * configurationRepository.findAllAsMap() >> [
-                (ConfigName.DIFFICULTY_LEVEL_MULTIPLIER)                : matchHardnessLvlMultiplier,
-                (ConfigName.DIFFICULTY_LEVEL_INCREMENTER)               : matchHardnessIncrementer,
-                (ConfigName.NUMBER_OF_EDGE_TEAMS)                       : edgeTeams as Double,
-                (ConfigName.DIFFICULTY_LEVEL_SAME_CITY_INCREMENTER)     : matchHardnessDerbyIncrementer,
-                (ConfigName.DIFFICULTY_LEVEL_MATCH_ON_TOP_INCREMENTER)  : matchHardnessTopIncrementer,
-                (ConfigName.DIFFICULTY_LEVEL_MATCH_ON_BOTTOM_INCREMENTER): matchHardnessBottomIncrementer
+                (ConfigName.DIFFICULTY_LEVEL_MULTIPLIER) : matchHardnessLvlMultiplier,
+                (ConfigName.DIFFICULTY_LEVEL_INCREMENTER): matchHardnessIncrementer,
+                (ConfigName.NUMBER_OF_EDGE_TEAMS)        : 1.0d
         ]
-        1 * teamRepository.count() >> 3
+        1 * teamRepository.count() >> 2
 
-        result.matchId() == matchId
-        result.parts().base() == (matchHardnessIncrementer - 20) * matchHardnessLvlMultiplier
-        result.parts().sameCity() == (isDerby ? matchHardnessDerbyIncrementer : 0.0d)
-        result.parts().top() == (isTopMatch ? matchHardnessTopIncrementer : 0.0d)
-        result.parts().bottom() == (isBottomMatch ? matchHardnessBottomIncrementer : 0.0d)
+        and: "the match's own instances stayed untouched — proving the numbers came from the table"
+        staleHome.points == (short) 0
+        staleHome.place == null
 
-        and: "the parts always add up to the total"
-        result.total() == result.parts().base() + result.parts().sameCity() + result.parts().top() + result.parts().bottom()
-
-        and: "top and bottom are mutually exclusive"
-        !(result.parts().top() > 0 && result.parts().bottom() > 0)
-
-        and: "flags mirror the parts"
-        result.flags().sameCity() == isDerby
-        result.flags().isTop() == isTopMatch
-        result.flags().isBot() == isBottomMatch
-        result.flags().pointsDiff() == 20
-
-        where:
-        awayTeamPlace | awayTeamCity | edgeTeams | isDerby | isTopMatch | isBottomMatch
-        1             | "city2"      | 0         | false   | false      | false
-        1             | "city2"      | 2         | false   | true       | false
-        3             | "city2"      | 2         | false   | false      | true
-        1             | "city1"      | 2         | true    | true       | false
-        3             | "city1"      | 2         | true    | false      | true
+        and: "the 3-point gap is still reflected in the score"
+        result.flags().pointsDiff() == MatchService.POINTS_FOR_WIN_MATCH
+        result.parts().base() == (matchHardnessIncrementer - MatchService.POINTS_FOR_WIN_MATCH) * matchHardnessLvlMultiplier
     }
 
     def "should not include top or bottom parts in breakdown when a team is unranked"() {
         given:
         def matchId = 8l
-        def homeTeam = [points: homePoints, place: homePlace, city: "city1"] as Team
-        def awayTeam = [points: awayPoints, place: awayPlace, city: "city2"] as Team
+        def homeTeam = [id: 1L, city: "city1"] as Team
+        def awayTeam = [id: 2L, city: "city2"] as Team
         def match = Match.builder().id(matchId).home(homeTeam).away(awayTeam).build()
+        // A team missing from the table has not played a finished match yet, so it has no
+        // place and cannot be classified into a table zone.
+        def table = leagueTable(pointsByTeamId, placeByTeamId)
         def matchHardnessLvlMultiplier = 1.0d
         def matchHardnessIncrementer = 100.0d
-
-        when:
-        def result = matchService.computeDifficultyBreakdown(matchId)
-
-        then:
-        1 * matchRepository.findById(matchId) >> Optional.of(match)
-        1 * matchRepository.findAllByHomeScoreNotNullAndAwayScoreNotNull() >> []
         // Deliberately no edge/top/bottom keys in the map — the unranked guard must return
         // before those values are ever read (a lookup would NPE and fail the test).
-        1 * configurationRepository.findAllAsMap() >> [
+        def config = [
                 (ConfigName.DIFFICULTY_LEVEL_MULTIPLIER) : matchHardnessLvlMultiplier,
                 (ConfigName.DIFFICULTY_LEVEL_INCREMENTER): matchHardnessIncrementer
         ]
-        1 * teamRepository.count() >> 3
 
+        when:
+        def result = matchService.computeBreakdown(match, table, config, 3)
+
+        then:
         result.parts().top() == 0.0d
         result.parts().bottom() == 0.0d
-        result.total() == (matchHardnessIncrementer - Math.abs(awayPoints - homePoints)) * matchHardnessLvlMultiplier
+        result.total() == (matchHardnessIncrementer - expectedPointsDiff) * matchHardnessLvlMultiplier
         !result.flags().isTop()
         !result.flags().isBot()
 
         where:
-        homePoints | homePlace | awayPoints | awayPlace
-        0          | null      | 0          | null
-        0          | null      | 30         | 1
-        30         | 1         | 0          | null
+        pointsByTeamId          | placeByTeamId | expectedPointsDiff
+        [:]                     | [:]           | 0
+        [(2L): 30]              | [(2L): 1]     | 30
+        [(1L): 30]              | [(1L): 1]     | 30
     }
 
     def "should refresh standings from finished matches before computing breakdown"() {
         given:
         def matchId = 5l
-        def team1 = [city: "city1"] as Team
-        def team2 = [city: "city2"] as Team
+        def team1 = [id: 1L, city: "city1"] as Team
+        def team2 = [id: 2L, city: "city2"] as Team
         def finishedMatches = [[homeScore: 2, awayScore: 0, home: team1, away: team2] as Match]
         def match = Match.builder().id(matchId).home(team1).away(team2).build()
         def matchHardnessLvlMultiplier = 2.0d
@@ -301,5 +357,16 @@ class MatchServiceSpec extends Specification {
         result.flags().pointsDiff() == MatchService.POINTS_FOR_WIN_MATCH
         result.parts().base() == (matchHardnessIncrementer - MatchService.POINTS_FOR_WIN_MATCH) * matchHardnessLvlMultiplier
         result.total() == result.parts().base()
+    }
+
+    /**
+     * Builds a {@link MatchService.LeagueTable} from plain int maps. The values must reach
+     * the record as Shorts — the record's accessors return a primitive short, so an Integer
+     * slipping in would blow up on unboxing rather than fail an assertion.
+     */
+    private static MatchService.LeagueTable leagueTable(Map<Long, Integer> points, Map<Long, Integer> places) {
+        new MatchService.LeagueTable(
+                points.collectEntries { id, value -> [(id): value as Short] },
+                places.collectEntries { id, value -> [(id): value as Short] })
     }
 }

--- a/src/test/groovy/com/jamex/refereestaffer/service/RefereeServiceSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/service/RefereeServiceSpec.groovy
@@ -41,6 +41,7 @@ class RefereeServiceSpec extends Specification {
     def "should fall back to default grade when referee has no matches"() {
         given:
         def referee = Referee.builder()
+                .id(1L)
                 .firstName("John")
                 .lastName("Smith")
                 .build()
@@ -57,6 +58,7 @@ class RefereeServiceSpec extends Specification {
     def "should fall back to default grade when referee's matches have no grades yet"() {
         given:
         def referee = Referee.builder()
+                .id(1L)
                 .firstName("John")
                 .lastName("Smith")
                 .build()
@@ -114,6 +116,7 @@ class RefereeServiceSpec extends Specification {
     def "should count home and away wins skipping draws and unfinished matches"() {
         given:
         def referee = Referee.builder()
+                .id(1L)
                 .firstName("John")
                 .lastName("Smith")
                 .build()
@@ -143,6 +146,7 @@ class RefereeServiceSpec extends Specification {
     def "should set zero win counters for referee without matches"() {
         given:
         def referee = Referee.builder()
+                .id(1L)
                 .firstName("John")
                 .lastName("Smith")
                 .build()
@@ -161,6 +165,7 @@ class RefereeServiceSpec extends Specification {
         def avgMultiplier = 6.0d
         def expMultiplier = 0.5d
         def referee = Referee.builder()
+                .id(1L)
                 .firstName("John")
                 .lastName("Smith")
                 .experience(10)
@@ -189,6 +194,7 @@ class RefereeServiceSpec extends Specification {
         def avgMultiplier = 6.0d
         def expMultiplier = 0.5d
         def referee = Referee.builder()
+                .id(1L)
                 .firstName("John")
                 .lastName("Smith")
                 .experience(4)
@@ -208,14 +214,17 @@ class RefereeServiceSpec extends Specification {
 
     static List<Referee> createReferees() {
         def ref1 = Referee.builder()
+                .id(1L)
                 .firstName("John")
                 .lastName("Smith")
                 .build()
         def ref2 = Referee.builder()
+                .id(2L)
                 .firstName("Affan")
                 .lastName("Bradshaw")
                 .build()
         def refSC = Referee.builder()
+                .id(3L)
                 .firstName("S")
                 .lastName("C")
                 .build()


### PR DESCRIPTION
## Ticket

[RS-75](https://referee-staffer.youtrack.cloud/issue/RS-75) — `spring.jpa.open-in-view: false`

Open Session In View has been on by default since forever (Spring Boot logs a WARN about it on every startup). It holds the Hibernate session open for the whole HTTP request, which masks lazy-loading problems and lets hidden queries run during DTO serialization. The ticket asks to disable it and fix whatever surfaces in the service layer (fetch joins / DTO projections) rather than reverting the flag.

## Plan

1. **Analysis before touching anything:** map every association in the model and every place a lazy proxy could leak past a transaction boundary.
   - The only `LAZY` association is `Referee.matches` (`@OneToMany`) — and `getMatches()` is never called anywhere.
   - All `@ManyToOne` / `@OneToOne` associations are JPA-default `EAGER`, so they are loaded at repository-call time.
   - No `getReferenceById()` / `getOne()` usages (those return lazy proxies).
2. Set `spring.jpa.open-in-view: false` in the base `application.yml` (inherited by `dev` and `prod`).
3. Add an integration spec that drives full HTTP requests through the real stack (controller → converter/service → real repositories → H2 → JSON), since the existing controller specs are `@WebMvcTest` slices with mocked repositories and can never catch a session-scope regression.
4. Run the whole backend suite, then boot the app and exercise every read endpoint plus the staffer flow.
5. Fix anything that surfaces in the service layer.

## Changes

- **`application.yml`** — `spring.jpa.open-in-view: false`. Dev and prod inherit it; the startup WARN is gone.
- **`RefereeService.calculateStats`** — grouped the bulk match query by the `Referee` *entity*, relying on Hibernate handing back the same managed instances the controller passed in. That only held because OSIV gave the request a single session. Without it the two queries run in separate sessions, the instances differ, and — since `Referee` compares by identity — every lookup missed, silently resetting referee stats to defaults. Now grouped by `getReferee().getId()`.
- **`MatchService` — difficulty scoring** (second commit, from the review finding below). `computeDifficultyBreakdown` loads the match in one persistence context and then ranks the teams from a *second* repository call in another, so `computeBreakdown` read `points`/`place` off `Team` instances no ranking pass had touched: HTTP 200, no exception, every match scored with `pointsDiff = 0` and no table-zone bonus. `calculatePointsForTeams` now returns a `LeagueTable` keyed by team id and the scoring reads from that — the same id-over-identity pattern already applied to `calculateStats`.
- **`OpenInViewDisabledIntegrationSpec`** (new) — full-context `@SpringBootTest` + MockMvc spec asserting `/api/matches/{id}`, `/api/referees`, `/api/teams/standings`, `/api/vacations` and `/api/matches/{id}/difficulty`. The difficulty feature asserts concrete numbers, not a 200. `@Isolated` + `SAME_THREAD` because it shares H2 with `StafferIntegrationSpec` under Spock's parallel runner.
- **`MatchServiceSpec` / `RefereeServiceSpec`** — fixtures now carry ids, and the zone/derby permutations call `computeBreakdown` with an explicit `LeagueTable` instead of fabricating `points`/`place` directly on `Team` entities. Those fixtures described a state production cannot produce: the transient fields are only ever written by a ranking pass.

### Deliberately out of scope

The ranking rules are untouched — only teams with a finished match are ranked, ordering is by points alone, ties keep encounter order. Pointing the algorithm at `TeamService.getStandings` (which ranks *all* teams with a goal-difference tie-break chain) would move matches between table zones and change match hardness. Disabling OSIV must leave the numbers identical, so that unification — and deleting `Team.points` / `Team.place` — is tracked as [RS-99](https://referee-staffer.youtrack.cloud/issue/RS-99). For the same reason the entity mutation in `calculatePointsForTeams` stays for now.

## Testing

- CI is green on Java 26, including the Maven backend job that runs the Spock suite.
- Locally `mvn -DskipFrontend=true test` — 150/150 green.
- **The new difficulty feature was verified to actually fail without the fix**: reverting `computeBreakdown` to entity reads makes it return `{"total":100.0,"parts":{"base":100.0,...},"flags":{"isTop":false,"pointsDiff":0}}` and the spec fails on `pointsDiff == 3`. This is the check the first round of this PR was missing — it asserted status codes and relation fields, which a silently-wrong number sails straight through.
- Manual end-to-end run (default profile): seeded two teams, a referee, a finished 2:1 match and a grade through the API. `/api/matches/1/difficulty` returns `total 104.0, base 97.0, top 7.0, isTop true, pointsDiff 3` — matching the pre-OSIV-change reference values — and the staffer reports the same `hardnessLvl 104.0` for the equivalent fixture, so the two screens finally agree. No OSIV startup WARN, zero `LazyInitializationException` in the logs.

🤖 Generated with Claude Code