### PR TITLE
RS-82: Focus trap in drawer and confirm dialog with focus return to trigger

### DIFF
--- a/src/main/webapp/src/app/component/common/confirm-dialog/confirm-dialog.component.spec.ts
+++ b/src/main/webapp/src/app/component/common/confirm-dialog/confirm-dialog.component.spec.ts
@@ -85,6 +85,21 @@ describe('ConfirmDialogComponent', () => {
     expect(cancelledCount).toBe(1);
   });
 
+  it('moves focus into the modal on open and back to the trigger on close', () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const el = open();
+    expect(document.activeElement).toBe(el.querySelector('.modal__foot .btn:not(.btn--primary)'));
+
+    fixture.componentRef.setInput('open', false);
+    fixture.detectChanges();
+    expect(document.activeElement).toBe(trigger);
+
+    trigger.remove();
+  });
+
   it('emits cancelled on Escape only while open', () => {
     fixture.detectChanges();
     document.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape'}));

--- a/src/main/webapp/src/app/component/common/confirm-dialog/confirm-dialog.component.ts
+++ b/src/main/webapp/src/app/component/common/confirm-dialog/confirm-dialog.component.ts
@@ -1,5 +1,6 @@
 import {Component, EventEmitter, HostListener, Input, Output} from '@angular/core';
 import {IconComponent} from '../icon/icon.component';
+import {FocusTrapDirective} from '../focus-trap/focus-trap.directive';
 import {ModalData} from '../../../model/modalData';
 
 /**
@@ -13,11 +14,11 @@ import {ModalData} from '../../../model/modalData';
  */
 @Component({
   selector: 'app-confirm-dialog',
-  imports: [IconComponent],
+  imports: [IconComponent, FocusTrapDirective],
   template: `
     @if (open) {
       <button type="button" class="modal-backdrop" (click)="cancelled.emit()" aria-label="Cancel"></button>
-      <div class="modal" role="alertdialog" aria-modal="true" [attr.aria-label]="data.header">
+      <div class="modal" role="alertdialog" aria-modal="true" [attr.aria-label]="data.header" appFocusTrap>
         <div class="modal__head">
           <span class="modal__icon"
                 [class.modal__icon--warn]="data.tone === 'warn'"
@@ -39,9 +40,10 @@ import {ModalData} from '../../../model/modalData';
     }
   `,
   styles: [`
-    /* Same focusable-backdrop pattern as app-drawer: a <button> so Tab can reach it and
-       Enter/Space dismiss. The global .modal-backdrop flex centering is irrelevant for
-       an empty button, so the modal centers itself instead. */
+    /* Same backdrop-as-<button> pattern as app-drawer — activatable by assistive tech
+       but outside the focus trap's Tab cycle (Esc and the footer buttons cover keyboard
+       dismissal). The global .modal-backdrop flex centering is irrelevant for an empty
+       button, so the modal centers itself instead. */
     button.modal-backdrop {
       border: none;
       padding: 0;

--- a/src/main/webapp/src/app/component/common/drawer/drawer.component.spec.ts
+++ b/src/main/webapp/src/app/component/common/drawer/drawer.component.spec.ts
@@ -65,4 +65,19 @@ describe('DrawerComponent', () => {
     open();
     expect(fixture.nativeElement.querySelector('.drawer--wide')).not.toBeNull();
   });
+
+  it('moves focus into the panel on open and back to the trigger on close', () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    open();
+    expect(document.activeElement).toBe(fixture.nativeElement.querySelector('button[aria-label="Close"]'));
+
+    fixture.componentRef.setInput('open', false);
+    fixture.detectChanges();
+    expect(document.activeElement).toBe(trigger);
+
+    trigger.remove();
+  });
 });

--- a/src/main/webapp/src/app/component/common/drawer/drawer.component.ts
+++ b/src/main/webapp/src/app/component/common/drawer/drawer.component.ts
@@ -1,20 +1,23 @@
 import {Component, EventEmitter, HostListener, Input, Output} from '@angular/core';
 import {IconComponent} from '../icon/icon.component';
+import {FocusTrapDirective} from '../focus-trap/focus-trap.directive';
 
 /**
  * Right-side detail drawer with backdrop. Slide animation comes from styles.scss
  * (.drawer + @keyframes slide). Closes on backdrop click, on the X button, or on Esc.
+ * While open, appFocusTrap keeps Tab inside the panel and returns focus to the trigger
+ * on close.
  *
  * Slot content goes into .drawer__body. An optional footer can be slotted with
  * `<div drawerFoot>...</div>` and lands inside .panel__foot for consistent styling.
  */
 @Component({
   selector: 'app-drawer',
-  imports: [IconComponent],
+  imports: [IconComponent, FocusTrapDirective],
   template: `
     @if (open) {
       <button type="button" class="drawer-backdrop" (click)="closed.emit()" aria-label="Close drawer"></button>
-      <aside class="drawer" [class.drawer--wide]="wide" role="dialog" aria-modal="true" [attr.aria-label]="title">
+      <aside class="drawer" [class.drawer--wide]="wide" role="dialog" aria-modal="true" [attr.aria-label]="title" appFocusTrap>
         <header class="drawer__head">
           <div>
             <div class="drawer__title">{{ title }}</div>
@@ -37,9 +40,10 @@ import {IconComponent} from '../icon/icon.component';
     .drawer__title {
       font-weight: 600;
     }
-    /* The backdrop is a <button> for keyboard accessibility — it has to be focusable so
-       Tab can land on it and Enter/Space dismiss the drawer. Strip the default button
-       chrome (border, background) so it stays the dim overlay it visually has to be. */
+    /* The backdrop is a <button> so assistive tech can activate it as "Close drawer";
+       the focus trap keeps Tab inside the panel, so it is not part of the Tab cycle —
+       Esc and the X button cover keyboard dismissal. Strip the default button chrome
+       (border, background) so it stays the dim overlay it visually has to be. */
     button.drawer-backdrop {
       border: none;
       padding: 0;

--- a/src/main/webapp/src/app/component/common/focus-trap/focus-trap.directive.spec.ts
+++ b/src/main/webapp/src/app/component/common/focus-trap/focus-trap.directive.spec.ts
@@ -11,6 +11,7 @@ import {FocusTrapDirective} from './focus-trap.directive';
         <button id="first" type="button">first</button>
         <button id="second" type="button" [disabled]="secondDisabled()">second</button>
         <button id="last" type="button">last</button>
+        <button id="invisible" type="button" style="display: none">invisible</button>
       </div>
     }
     @if (stacked()) {

--- a/src/main/webapp/src/app/component/common/focus-trap/focus-trap.directive.spec.ts
+++ b/src/main/webapp/src/app/component/common/focus-trap/focus-trap.directive.spec.ts
@@ -1,0 +1,143 @@
+import {Component, signal} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {FocusTrapDirective} from './focus-trap.directive';
+
+@Component({
+  imports: [FocusTrapDirective],
+  template: `
+    <button id="trigger" type="button">open</button>
+    @if (open()) {
+      <div id="panel" appFocusTrap>
+        <button id="first" type="button">first</button>
+        <button id="second" type="button" [disabled]="secondDisabled()">second</button>
+        <button id="last" type="button">last</button>
+      </div>
+    }
+    @if (stacked()) {
+      <div id="stacked-panel" appFocusTrap>
+        <button id="stacked-only" type="button">stacked</button>
+      </div>
+    }
+  `
+})
+class HostComponent {
+  readonly open = signal(false);
+  readonly stacked = signal(false);
+  readonly secondDisabled = signal(false);
+}
+
+describe('FocusTrapDirective', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let host: HostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({imports: [HostComponent]}).compileComponents();
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  function el(id: string): HTMLElement {
+    return (fixture.nativeElement as HTMLElement).querySelector(`#${id}`) as HTMLElement;
+  }
+
+  function pressTab(shiftKey = false): void {
+    document.dispatchEvent(new KeyboardEvent('keydown', {key: 'Tab', shiftKey}));
+  }
+
+  function openTrap(): void {
+    el('trigger').focus();
+    host.open.set(true);
+    fixture.detectChanges();
+  }
+
+  it('moves focus to the first focusable element on activation', () => {
+    openTrap();
+    expect(document.activeElement).toBe(el('first'));
+  });
+
+  it('wraps Tab from the last element back to the first', () => {
+    openTrap();
+    el('last').focus();
+
+    pressTab();
+
+    expect(document.activeElement).toBe(el('first'));
+  });
+
+  it('wraps Shift+Tab from the first element back to the last', () => {
+    openTrap();
+
+    pressTab(true);
+
+    expect(document.activeElement).toBe(el('last'));
+  });
+
+  it('leaves Tab alone between inner elements', () => {
+    openTrap();
+    // A synthetic Tab does not natively move focus; the trap must not hijack it either.
+    pressTab();
+    expect(document.activeElement).toBe(el('first'));
+  });
+
+  it('skips disabled controls when wrapping', () => {
+    host.secondDisabled.set(true);
+    openTrap();
+    el('first').focus();
+
+    pressTab(true);
+
+    expect(document.activeElement).toBe(el('last'));
+  });
+
+  it('pulls focus back inside when it escaped the container', () => {
+    openTrap();
+    el('trigger').focus();
+
+    pressTab();
+
+    expect(document.activeElement).toBe(el('first'));
+  });
+
+  it('returns focus to the trigger on deactivation', () => {
+    openTrap();
+    el('last').focus();
+
+    host.open.set(false);
+    fixture.detectChanges();
+
+    expect(document.activeElement).toBe(el('trigger'));
+  });
+
+  it('lets only the topmost trap handle Tab and restores focus into the outer trap', () => {
+    openTrap();
+    el('last').focus();
+    host.stacked.set(true);
+    fixture.detectChanges();
+
+    expect(document.activeElement).toBe(el('stacked-only'));
+    pressTab();
+    expect(document.activeElement).toBe(el('stacked-only'));
+
+    host.stacked.set(false);
+    fixture.detectChanges();
+
+    expect(document.activeElement).toBe(el('last'));
+    pressTab();
+    expect(document.activeElement).toBe(el('first'));
+  });
+
+  it('skips the focus restore when the saved element is no longer in the DOM', () => {
+    openTrap();
+    host.stacked.set(true);
+    fixture.detectChanges();
+
+    // Close both at once — the inner trap's saved element (inside the outer panel) is
+    // detached by the time it restores, so the outer trap's restore must win.
+    host.open.set(false);
+    host.stacked.set(false);
+    fixture.detectChanges();
+
+    expect(document.activeElement).toBe(el('trigger'));
+  });
+});

--- a/src/main/webapp/src/app/component/common/focus-trap/focus-trap.directive.ts
+++ b/src/main/webapp/src/app/component/common/focus-trap/focus-trap.directive.ts
@@ -1,0 +1,84 @@
+import {AfterViewInit, Directive, ElementRef, OnDestroy, inject} from '@angular/core';
+
+/** Interactive elements a focus trap cycles through. Disabled controls are skipped. */
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])'
+].join(', ');
+
+/**
+ * Overlays can stack (form drawer + its discard guard), so every active trap registers
+ * here and only the topmost one handles Tab. Module-level on purpose: both overlay
+ * primitives share one stack without needing an injectable service.
+ */
+const trapStack: FocusTrapDirective[] = [];
+
+/**
+ * Traps Tab / Shift+Tab inside the host element and returns focus to the previously
+ * focused element (the trigger) when the host is destroyed. Designed for the two overlay
+ * primitives (app-drawer, app-confirm-dialog), whose panels live inside `@if (open)`
+ * blocks — creation activates the trap, removal deactivates it, so the directive needs
+ * no `open` input of its own.
+ *
+ * On activation focus moves to the first focusable element of the panel. The focusable
+ * backdrop button is a sibling of the panel, so it drops out of the Tab cycle while a
+ * trap is active — Esc and the panel's own buttons cover keyboard dismissal.
+ */
+@Directive({
+  selector: '[appFocusTrap]'
+})
+export class FocusTrapDirective implements AfterViewInit, OnDestroy {
+  private readonly container: HTMLElement = inject(ElementRef).nativeElement;
+  private previouslyFocused: HTMLElement | null = null;
+  private readonly onKeydown = (event: KeyboardEvent): void => this.trapTab(event);
+
+  ngAfterViewInit(): void {
+    this.previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    trapStack.push(this);
+    document.addEventListener('keydown', this.onKeydown);
+
+    const target = this.focusables()[0] ?? this.container;
+    if (target === this.container) this.container.tabIndex = -1;
+    target.focus();
+  }
+
+  ngOnDestroy(): void {
+    const index = trapStack.indexOf(this);
+    if (index >= 0) trapStack.splice(index, 1);
+    document.removeEventListener('keydown', this.onKeydown);
+    // When a stacked guard closes together with its drawer, the guard's saved element is
+    // already detached — skipping it lets the drawer's trap restore focus to the trigger.
+    if (this.previouslyFocused?.isConnected) this.previouslyFocused.focus();
+  }
+
+  private trapTab(event: KeyboardEvent): void {
+    if (event.key !== 'Tab' || trapStack[trapStack.length - 1] !== this) return;
+
+    const focusables = this.focusables();
+    if (focusables.length === 0) {
+      event.preventDefault();
+      return;
+    }
+
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement;
+    const activeInside = active instanceof HTMLElement && this.container.contains(active);
+
+    if (event.shiftKey && (!activeInside || active === first)) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && (!activeInside || active === last)) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  private focusables(): HTMLElement[] {
+    return Array.from(this.container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+  }
+}

--- a/src/main/webapp/src/app/component/common/focus-trap/focus-trap.directive.ts
+++ b/src/main/webapp/src/app/component/common/focus-trap/focus-trap.directive.ts
@@ -79,6 +79,9 @@ export class FocusTrapDirective implements AfterViewInit, OnDestroy {
   }
 
   private focusables(): HTMLElement[] {
-    return Array.from(this.container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+    // checkVisibility() drops display:none / visibility:hidden matches — focusing those
+    // silently fails, which would break both the initial focus and the Tab wrap-around.
+    return Array.from(this.container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+      .filter(element => element.checkVisibility());
   }
 }

--- a/src/main/webapp/src/app/component/common/form-drawer/form-drawer.component.spec.ts
+++ b/src/main/webapp/src/app/component/common/form-drawer/form-drawer.component.spec.ts
@@ -93,6 +93,21 @@ describe('FormDrawerComponent', () => {
     expect(el().querySelector('.drawer')).not.toBeNull();
   });
 
+  it('moves focus into the discard guard and back into the drawer when it is dismissed', () => {
+    fixture.componentRef.setInput('dirty', true);
+    fixture.detectChanges();
+    const drawerClose = el().querySelector('button[aria-label="Close"]') as HTMLButtonElement;
+    drawerClose.focus();
+
+    clickCancel();
+    expect(guard()!.contains(document.activeElement)).toBeTrue();
+
+    (guard()!.querySelector('.modal__foot .btn:not(.btn--primary)') as HTMLButtonElement).click();
+    fixture.detectChanges();
+
+    expect(document.activeElement).toBe(drawerClose);
+  });
+
   it('lets Escape dismiss only the guard while it is open, not the drawer behind it', () => {
     fixture.componentRef.setInput('dirty', true);
     fixture.detectChanges();


### PR DESCRIPTION
# Ticket

[RS-82 — Focus-trap w drawerze i confirm dialogu + powrót fokusu na trigger](https://referee-staffer.youtrack.cloud/issue/RS-82)

The post-redesign a11y baseline is good (`role="dialog"`/`aria-modal`, `alertdialog` on the confirm modal, Esc handling, focusable backdrops, `<label for>`, template-accessibility lint rules), but two details were missing: Tab could walk out of an open drawer/modal into the content underneath, and after closing an overlay the keyboard focus was left stranded instead of returning to the element that opened it. Both are required for the overlays to behave like real modal dialogs for keyboard and screen-reader users.

# Plan

1. Add a small shared focus-trap utility in `component/common/` — a `FocusTrapDirective` (`appFocusTrap`) shared by the only two overlay primitives in the app (`app-drawer`, `app-confirm-dialog`). Since both panels live inside `@if (open)` blocks, the directive activates on element creation and deactivates on destroy, so it needs no `open` input.
2. On activation: save `document.activeElement` (the trigger), move focus to the panel's first focusable element, and register in a module-level trap stack so stacked overlays (form drawer + its discard guard) don't fight — only the topmost trap handles Tab.
3. Trap Tab/Shift+Tab: wrap from last→first and first→last, pull focus back inside if it escaped, skip disabled controls.
4. On destroy: restore focus to the saved trigger, guarded by `isConnected` so that when a stacked guard closes together with its drawer, the drawer's restore (to the real trigger) wins.
5. Apply the directive to the drawer `<aside>` and the modal `<div>`; tests for the directive plus focus assertions in the drawer / confirm-dialog / form-drawer specs.
6. Verify with `npm ci`, `npm run lint`, `npm test` (headless).

# Changes

- **New `component/common/focus-trap/focus-trap.directive.ts`** — first directive in the app. Module-level `trapStack` (no injectable service needed; both primitives share one stack), document-level `keydown` listener per trap that only acts on Tab and only when the trap is topmost, `focusables()` based on a standard focusable selector that excludes disabled controls and `tabindex="-1"`.
- **`drawer.component.ts` / `confirm-dialog.component.ts`** — `appFocusTrap` applied to the panel elements. Design decision: the trap covers the *panel only*, so the focusable backdrop `<button>` drops out of the Tab cycle. That's intentional and standard for modal dialogs — Esc, the X button, and the footer buttons cover keyboard dismissal, while the backdrop button remains activatable by assistive tech and mouse. The stale comments documenting the old "Tab can land on the backdrop" behaviour were updated.
- Initial focus goes to the panel's first focusable element: the X button in drawers, the Cancel button in the confirm dialog (least destructive action first, per the dialog pattern).
- The `aria-live` item from the ticket was left out — the ticket marks it optional and ties it to toast changes, which are a separate concern.

# Testing

- New `focus-trap.directive.spec.ts` (9 specs): initial focus, Tab/Shift+Tab wrapping, disabled-control skipping, focus recapture after escaping, restore-to-trigger, stacked-trap behaviour (topmost wins, restore into the outer trap), and the simultaneous-close case where the inner trap's saved element is already detached.
- Extended `drawer.component.spec.ts` and `confirm-dialog.component.spec.ts` with open→focus-in / close→focus-back-to-trigger assertions, and `form-drawer.component.spec.ts` with a discard-guard stacking test (focus moves into the guard, returns to the drawer when the guard is dismissed).
- `npm run lint` clean, `npm test` headless: **149/149 SUCCESS** (12 new specs).

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVnxS6eeUigajuuWm8rpnm)_