### PR TITLE
RS-84: Drive edge-team zones from backend configuration

### DIFF
--- a/src/main/webapp/src/app/component/dashboard/dashboard.component.spec.ts
+++ b/src/main/webapp/src/app/component/dashboard/dashboard.component.spec.ts
@@ -1,10 +1,12 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {signal, WritableSignal} from '@angular/core';
 import {provideRouter} from '@angular/router';
 import {of} from 'rxjs';
 import {DashboardComponent} from './dashboard.component';
 import {MatchService} from '../../service/match.service';
 import {RefereeService} from '../../service/referee.service';
 import {TeamService} from '../../service/team.service';
+import {ConfigurationService} from '../../service/configuration.service';
 import {Match} from '../../model/match';
 import {Referee} from '../../model/referee';
 import {Standing, Standings} from '../../model/standing';
@@ -13,6 +15,7 @@ describe('DashboardComponent', () => {
   let matchService: jasmine.SpyObj<MatchService>;
   let refereeService: jasmine.SpyObj<RefereeService>;
   let teamService: jasmine.SpyObj<TeamService>;
+  let edgeTeams: WritableSignal<number>;
 
   // /api/teams/standings returns table order; 8 teams so both edge zones exist.
   const rows: Standing[] = Array.from({length: 8}, (_, i) => ({
@@ -72,6 +75,7 @@ describe('DashboardComponent', () => {
     matchService.findAll.and.returnValue(of(matches));
     refereeService.findAll.and.returnValue(of(referees));
     teamService.getStandings.and.returnValue(of(standings));
+    edgeTeams = signal(3);
 
     await TestBed.configureTestingModule({
       imports: [DashboardComponent],
@@ -79,7 +83,8 @@ describe('DashboardComponent', () => {
         provideRouter([]),
         {provide: MatchService, useValue: matchService},
         {provide: RefereeService, useValue: refereeService},
-        {provide: TeamService, useValue: teamService}
+        {provide: TeamService, useValue: teamService},
+        {provide: ConfigurationService, useValue: {edgeTeams: edgeTeams.asReadonly(), ensureEdgeTeamsLoaded: jasmine.createSpy('ensureEdgeTeamsLoaded')}}
       ]
     }).compileComponents();
   });
@@ -155,6 +160,16 @@ describe('DashboardComponent', () => {
 
     expect(component.zoneFor(2)).toBe('top');
     expect(component.zoneFor(4)).toBeNull();
+  });
+
+  it('follows the configured edge size for the standings zones', () => {
+    edgeTeams.set(2);
+    const component = create().componentInstance;
+
+    expect([0, 1].map(i => component.zoneFor(i))).toEqual(['top', 'top']);
+    expect(component.zoneFor(2)).toBeNull();
+    expect(component.zoneFor(5)).toBeNull();
+    expect([6, 7].map(i => component.zoneFor(i))).toEqual(['relegation', 'relegation']);
   });
 
   it('scales points bars against the leader and flags three-digit difficulty', () => {

--- a/src/main/webapp/src/app/component/dashboard/dashboard.component.ts
+++ b/src/main/webapp/src/app/component/dashboard/dashboard.component.ts
@@ -7,13 +7,12 @@ import {Team} from '../../model/team';
 import {MatchService} from '../../service/match.service';
 import {RefereeService} from '../../service/referee.service';
 import {TeamService} from '../../service/team.service';
+import {ConfigurationService} from '../../service/configuration.service';
 import {IconComponent} from '../common/icon/icon.component';
 import {KpiComponent} from '../common/kpi/kpi.component';
 import {TeamPillComponent} from '../common/team-pill/team-pill.component';
 import {RefAvatarComponent} from '../common/ref-avatar/ref-avatar.component';
 import {MeterComponent} from '../common/meter/meter.component';
-
-const NUMBER_OF_EDGE_TEAMS = 3;
 
 /**
  * Overview — at-a-glance dashboard.
@@ -38,6 +37,10 @@ export class DashboardComponent implements OnInit {
   private readonly matchService = inject(MatchService);
   private readonly refereeService = inject(RefereeService);
   private readonly teamService = inject(TeamService);
+  private readonly configurationService = inject(ConfigurationService);
+
+  /** Edge-zone size (NUMBER_OF_EDGE_TEAMS) from the backend configuration. */
+  readonly edgeTeams = this.configurationService.edgeTeams;
 
   readonly matches = signal<Match[]>([]);
   readonly referees = signal<Referee[]>([]);
@@ -95,6 +98,7 @@ export class DashboardComponent implements OnInit {
   });
 
   ngOnInit(): void {
+    this.configurationService.ensureEdgeTeamsLoaded();
     forkJoin({
       matches: this.matchService.findAll(),
       referees: this.refereeService.findAll(),
@@ -138,8 +142,9 @@ export class DashboardComponent implements OnInit {
 
   zoneFor(index: number): 'top' | 'relegation' | null {
     const total = this.standingsTotal();
-    if (index < NUMBER_OF_EDGE_TEAMS) return 'top';
-    if (index >= total - NUMBER_OF_EDGE_TEAMS && total >= NUMBER_OF_EDGE_TEAMS * 2) return 'relegation';
+    const edge = this.edgeTeams();
+    if (index < edge) return 'top';
+    if (index >= total - edge && total >= edge * 2) return 'relegation';
     return null;
   }
 }

--- a/src/main/webapp/src/app/component/match-detail/match-detail.component.html
+++ b/src/main/webapp/src/app/component/match-detail/match-detail.component.html
@@ -59,7 +59,7 @@
     </div>
     <div class="hero-flags">
       @if (sameCity()) { <app-chip variant="warn">derby — same city</app-chip> }
-      @if (isTopMatch()) { <app-chip variant="accent">top-3 match</app-chip> }
+      @if (isTopMatch()) { <app-chip variant="accent">top-{{ edgeTeams() }} match</app-chip> }
       @if (isRelegationMatch()) { <app-chip variant="danger">relegation match</app-chip> }
       <app-chip>Δ pts {{ pointsDiff() }}</app-chip>
       @if (m.hardnessLvl !== null) {
@@ -94,7 +94,7 @@
                 <td class="num right" [class.warn-text]="b.flags.sameCity" [class.muted]="!b.flags.sameCity">+{{ round(b.parts.sameCity) }}</td>
               </tr>
               <tr>
-                <td>Top-3 match</td>
+                <td>Top-{{ edgeTeams() }} match</td>
                 <td class="num right muted">{{ b.flags.isTop ? 'active' : 'inactive' }}</td>
                 <td class="num right" [class.accent-text]="b.flags.isTop" [class.muted]="!b.flags.isTop">+{{ round(b.parts.top) }}</td>
               </tr>

--- a/src/main/webapp/src/app/component/match-detail/match-detail.component.spec.ts
+++ b/src/main/webapp/src/app/component/match-detail/match-detail.component.spec.ts
@@ -1,10 +1,12 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {signal, WritableSignal} from '@angular/core';
 import {ActivatedRoute, convertToParamMap, provideRouter, Router} from '@angular/router';
 import {of} from 'rxjs';
 import {MatchDetailComponent} from './match-detail.component';
 import {MatchService} from '../../service/match.service';
 import {TeamService} from '../../service/team.service';
 import {RefereeService} from '../../service/referee.service';
+import {ConfigurationService} from '../../service/configuration.service';
 import {Match} from '../../model/match';
 import {Standings} from '../../model/standing';
 import {Referee} from '../../model/referee';
@@ -14,6 +16,7 @@ describe('MatchDetailComponent', () => {
   let matchService: jasmine.SpyObj<MatchService>;
   let teamService: jasmine.SpyObj<TeamService>;
   let refereeService: jasmine.SpyObj<RefereeService>;
+  let edgeTeams: WritableSignal<number>;
   let navigateSpy: jasmine.Spy;
 
   // Backend rows carry `place`. Teams 1 and 2 share a city so the local same-city
@@ -86,6 +89,7 @@ describe('MatchDetailComponent', () => {
     matchService.getDifficultyBreakdown.and.returnValue(of(breakdown));
     teamService.getStandings.and.returnValue(of(standings));
     refereeService.findAll.and.returnValue(of(referees));
+    edgeTeams = signal(3);
   });
 
   async function create(id?: number): Promise<ComponentFixture<MatchDetailComponent>> {
@@ -98,6 +102,7 @@ describe('MatchDetailComponent', () => {
         {provide: MatchService, useValue: matchService},
         {provide: TeamService, useValue: teamService},
         {provide: RefereeService, useValue: refereeService},
+        {provide: ConfigurationService, useValue: {edgeTeams: edgeTeams.asReadonly(), ensureEdgeTeamsLoaded: jasmine.createSpy('ensureEdgeTeamsLoaded')}},
         {
           provide: ActivatedRoute,
           useValue: {snapshot: {paramMap: convertToParamMap(id ? {id: String(id)} : {})}}
@@ -158,6 +163,18 @@ describe('MatchDetailComponent', () => {
     expect(component.isRelegationMatch()).toBeTrue();
     expect(component.isTopMatch()).toBeFalse();
     expect(component.sameCity()).toBeFalse();
+  });
+
+  it('follows the configured edge size in the local flag fallback', async () => {
+    matchService.getDifficultyBreakdown.and.returnValue(of(null as unknown as DifficultyBreakdown));
+    // Places 1 vs 3: a top pairing with edge 3, but not once the edge shrinks to 2.
+    matchService.findById.and.returnValue(of(makeMatch({homeTeamId: 1, awayTeamId: 3})));
+    edgeTeams.set(2);
+
+    const component = (await create(11)).componentInstance;
+
+    expect(component.isTopMatch()).toBeFalse();
+    expect(component.isRelegationMatch()).toBeFalse();
   });
 
   it('ranks candidates by potential and marks the assigned one', async () => {

--- a/src/main/webapp/src/app/component/match-detail/match-detail.component.ts
+++ b/src/main/webapp/src/app/component/match-detail/match-detail.component.ts
@@ -8,11 +8,10 @@ import {DifficultyBreakdown} from '../../model/difficultyBreakdown';
 import {MatchService} from '../../service/match.service';
 import {TeamService} from '../../service/team.service';
 import {RefereeService} from '../../service/referee.service';
+import {ConfigurationService} from '../../service/configuration.service';
 import {IconComponent} from '../common/icon/icon.component';
 import {ChipComponent} from '../common/chip/chip.component';
 import {RefAvatarComponent} from '../common/ref-avatar/ref-avatar.component';
-
-const NUMBER_OF_EDGE_TEAMS = 3;
 
 interface CompareRow {
   label: string;
@@ -42,6 +41,10 @@ export class MatchDetailComponent implements OnInit {
   private readonly matchService = inject(MatchService);
   private readonly teamService = inject(TeamService);
   private readonly refereeService = inject(RefereeService);
+  private readonly configurationService = inject(ConfigurationService);
+
+  /** Edge-zone size (NUMBER_OF_EDGE_TEAMS) from the backend configuration. */
+  readonly edgeTeams = this.configurationService.edgeTeams;
 
   readonly match = signal<Match | null>(null);
   readonly breakdown = signal<DifficultyBreakdown | null>(null);
@@ -79,7 +82,8 @@ export class MatchDetailComponent implements OnInit {
     if (flags) return flags.isTop;
     const hp = this.homePlace();
     const ap = this.awayPlace();
-    return hp != null && ap != null && hp <= NUMBER_OF_EDGE_TEAMS && ap <= NUMBER_OF_EDGE_TEAMS;
+    const edge = this.edgeTeams();
+    return hp != null && ap != null && hp <= edge && ap <= edge;
   });
 
   readonly isRelegationMatch = computed(() => {
@@ -88,9 +92,10 @@ export class MatchDetailComponent implements OnInit {
     const hp = this.homePlace();
     const ap = this.awayPlace();
     const total = this.standings().length;
+    const edge = this.edgeTeams();
     return hp != null && ap != null && total > 0
-      && hp > total - NUMBER_OF_EDGE_TEAMS
-      && ap > total - NUMBER_OF_EDGE_TEAMS;
+      && hp > total - edge
+      && ap > total - edge;
   });
 
   readonly compareRows = computed<CompareRow[]>(() => {
@@ -128,6 +133,7 @@ export class MatchDetailComponent implements OnInit {
       this.router.navigate(['/matches']);
       return;
     }
+    this.configurationService.ensureEdgeTeamsLoaded();
     forkJoin({
       match: this.matchService.findById(matchId),
       breakdown: this.matchService.getDifficultyBreakdown(matchId),

--- a/src/main/webapp/src/app/component/staffer/staffer.component.html
+++ b/src/main/webapp/src/app/component/staffer/staffer.component.html
@@ -109,7 +109,7 @@
                 @let f = flags(match);
                 <div class="flag-cell">
                   @if (f.sameCity) { <app-chip variant="warn">derby</app-chip> }
-                  @if (f.isTop) { <app-chip variant="accent">top-3</app-chip> }
+                  @if (f.isTop) { <app-chip variant="accent">top-{{ edgeTeams() }}</app-chip> }
                   @if (f.isBot) { <app-chip variant="danger">relegation</app-chip> }
                   @if (hasNoFlags(match)) { <span class="muted">—</span> }
                 </div>
@@ -206,7 +206,7 @@
                   <td class="num right" [class.warn-text]="b.flags.sameCity" [class.muted]="!b.flags.sameCity">+{{ round(b.parts.sameCity) }}</td>
                 </tr>
                 <tr>
-                  <td>Top-3 match</td>
+                  <td>Top-{{ edgeTeams() }} match</td>
                   <td class="num right" [class.accent-text]="b.flags.isTop" [class.muted]="!b.flags.isTop">+{{ round(b.parts.top) }}</td>
                 </tr>
                 <tr>

--- a/src/main/webapp/src/app/component/staffer/staffer.component.spec.ts
+++ b/src/main/webapp/src/app/component/staffer/staffer.component.spec.ts
@@ -6,6 +6,7 @@ import {StafferService} from '../../service/staffer.service';
 import {TeamService} from '../../service/team.service';
 import {RefereeService} from '../../service/referee.service';
 import {MatchService} from '../../service/match.service';
+import {ConfigurationService} from '../../service/configuration.service';
 import {UiSettingsService} from '../../service/ui-settings.service';
 import {Match} from '../../model/match';
 import {Standings} from '../../model/standing';
@@ -20,9 +21,10 @@ describe('StafferComponent', () => {
   let refereeService: jasmine.SpyObj<RefereeService>;
   let matchService: jasmine.SpyObj<MatchService>;
   let explainerVisible: WritableSignal<boolean>;
+  let edgeTeams: WritableSignal<number>;
 
-  // Backend rows carry `place`. 8 teams, NUMBER_OF_EDGE_TEAMS = 3, so top = both
-  // places <= 3, bottom = both places > 5. Teams 1 and 2 share a city.
+  // Backend rows carry `place`. 8 teams, edge size 3 (stubbed ConfigurationService),
+  // so top = both places <= 3, bottom = both places > 5. Teams 1 and 2 share a city.
   const standings: Standings = {
     afterQueue: 10,
     rows: [
@@ -97,6 +99,7 @@ describe('StafferComponent', () => {
     refereeService = jasmine.createSpyObj('RefereeService', ['findRefereesAvailableForQueue']);
     matchService = jasmine.createSpyObj('MatchService', ['getDifficultyBreakdown', 'updateList']);
     explainerVisible = signal(false);
+    edgeTeams = signal(3);
 
     stafferService.staffReferees.and.returnValue(of(matches));
     teamService.getStandings.and.returnValue(of(standings));
@@ -111,6 +114,7 @@ describe('StafferComponent', () => {
         {provide: TeamService, useValue: teamService},
         {provide: RefereeService, useValue: refereeService},
         {provide: MatchService, useValue: matchService},
+        {provide: ConfigurationService, useValue: {edgeTeams: edgeTeams.asReadonly(), ensureEdgeTeamsLoaded: jasmine.createSpy('ensureEdgeTeamsLoaded')}},
         {provide: UiSettingsService, useValue: {explainerVisible: explainerVisible.asReadonly()}}
       ]
     }).compileComponents();
@@ -350,6 +354,17 @@ describe('StafferComponent', () => {
 
     it('degrades to no flags for teams missing from the standings', () => {
       expect(component.hasNoFlags(makeMatch(28, {homeTeamId: 998, awayTeamId: 999}))).toBeTrue();
+    });
+
+    it('follows the configured edge size instead of a hardcoded 3', () => {
+      edgeTeams.set(2);
+
+      // Places 1 vs 3 stop being a top pairing once the edge shrinks to 2...
+      expect(component.flags(makeMatch(29, {homeTeamId: 1, awayTeamId: 3})).isTop).toBeFalse();
+      expect(component.flags(makeMatch(30, {homeTeamId: 1, awayTeamId: 2})).isTop).toBeTrue();
+      // ...and places 6 vs 8 leave the relegation zone (now places > 6).
+      expect(component.flags(makeMatch(31, {homeTeamId: 6, awayTeamId: 8})).isBot).toBeFalse();
+      expect(component.flags(makeMatch(32, {homeTeamId: 7, awayTeamId: 8})).isBot).toBeTrue();
     });
   });
 

--- a/src/main/webapp/src/app/component/staffer/staffer.component.ts
+++ b/src/main/webapp/src/app/component/staffer/staffer.component.ts
@@ -4,6 +4,7 @@ import {StafferService} from '../../service/staffer.service';
 import {TeamService} from '../../service/team.service';
 import {RefereeService} from '../../service/referee.service';
 import {MatchService} from '../../service/match.service';
+import {ConfigurationService} from '../../service/configuration.service';
 import {UiSettingsService} from '../../service/ui-settings.service';
 import {Match} from '../../model/match';
 import {Team} from '../../model/team';
@@ -29,8 +30,6 @@ interface Candidate {
   isUsedElsewhere: boolean;
 }
 
-const NUMBER_OF_EDGE_TEAMS = 3;
-
 /**
  * Staffer — the auto-assignment workspace. Pick a queue, generate the cast, lock or
  * swap individual rows, then save.
@@ -53,8 +52,12 @@ export class StafferComponent {
   private readonly teamService = inject(TeamService);
   private readonly refereeService = inject(RefereeService);
   private readonly matchService = inject(MatchService);
+  private readonly configurationService = inject(ConfigurationService);
   /** Gates the "How the staffer scores assignments" panel (toggled in the sidebar's Admin section). */
   readonly settings = inject(UiSettingsService);
+
+  /** Edge-zone size (NUMBER_OF_EDGE_TEAMS) from the backend configuration. */
+  readonly edgeTeams = this.configurationService.edgeTeams;
 
   readonly queue = signal(1);
   readonly matches = signal<Match[] | null>(null);
@@ -77,6 +80,10 @@ export class StafferComponent {
   readonly drawerBreakdown = signal<DifficultyBreakdown | null>(null);
   readonly savedAt = signal<Date | null>(null);
   readonly loading = signal(false);
+
+  constructor() {
+    this.configurationService.ensureEdgeTeamsLoaded();
+  }
 
   // ——— Derived state ———
 
@@ -212,10 +219,11 @@ export class StafferComponent {
     const awayPlace = this.placeById().get(match.awayTeamId);
     const total = this.totalTeams();
 
+    const edge = this.edgeTeams();
     const sameCity = !!(home?.city && away?.city && home.city === away.city);
-    const isTop = !!(homePlace && awayPlace && homePlace <= NUMBER_OF_EDGE_TEAMS && awayPlace <= NUMBER_OF_EDGE_TEAMS);
+    const isTop = !!(homePlace && awayPlace && homePlace <= edge && awayPlace <= edge);
     const isBot = !!(homePlace && awayPlace && total > 0
-      && homePlace > total - NUMBER_OF_EDGE_TEAMS && awayPlace > total - NUMBER_OF_EDGE_TEAMS);
+      && homePlace > total - edge && awayPlace > total - edge);
     return {sameCity, isTop, isBot};
   }
 

--- a/src/main/webapp/src/app/component/standings/standings.component.html
+++ b/src/main/webapp/src/app/component/standings/standings.component.html
@@ -8,7 +8,7 @@
       }
     </div>
   </div>
-  <app-seg [options]="filterOptions" [value]="filter()" (valueChange)="filter.set($event)"></app-seg>
+  <app-seg [options]="filterOptions()" [value]="filter()" (valueChange)="filter.set($event)"></app-seg>
 </div>
 
 <div class="panel">

--- a/src/main/webapp/src/app/component/standings/standings.component.spec.ts
+++ b/src/main/webapp/src/app/component/standings/standings.component.spec.ts
@@ -1,11 +1,14 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {signal, WritableSignal} from '@angular/core';
 import {of} from 'rxjs';
 import {StandingsComponent} from './standings.component';
 import {TeamService} from '../../service/team.service';
+import {ConfigurationService} from '../../service/configuration.service';
 import {Standing, Standings} from '../../model/standing';
 
 describe('StandingsComponent', () => {
   let teamService: jasmine.SpyObj<TeamService>;
+  let edgeTeams: WritableSignal<number>;
 
   // /api/teams/standings returns the computed table; 8 teams so both edge zones exist.
   const rows: Standing[] = Array.from({length: 8}, (_, i) => ({
@@ -19,11 +22,13 @@ describe('StandingsComponent', () => {
   beforeEach(async () => {
     teamService = jasmine.createSpyObj('TeamService', ['getStandings']);
     teamService.getStandings.and.returnValue(of(standings));
+    edgeTeams = signal(3);
 
     await TestBed.configureTestingModule({
       imports: [StandingsComponent],
       providers: [
-        {provide: TeamService, useValue: teamService}
+        {provide: TeamService, useValue: teamService},
+        {provide: ConfigurationService, useValue: {edgeTeams: edgeTeams.asReadonly(), ensureEdgeTeamsLoaded: jasmine.createSpy('ensureEdgeTeamsLoaded')}}
       ]
     }).compileComponents();
   });
@@ -58,6 +63,16 @@ describe('StandingsComponent', () => {
 
     expect(componentRows.filter(r => r.zone === 'accent').map(r => r.standing.place)).toEqual([1, 2, 3]);
     expect(componentRows.some(r => r.zone === 'danger')).toBeFalse();
+  });
+
+  it('derives zones and filter labels from the configured edge size', () => {
+    edgeTeams.set(2);
+    const component = create().componentInstance;
+
+    const componentRows = component.rows();
+    expect(componentRows.filter(r => r.zone === 'accent').map(r => r.standing.place)).toEqual([1, 2]);
+    expect(componentRows.filter(r => r.zone === 'danger').map(r => r.standing.place)).toEqual([7, 8]);
+    expect(component.filterOptions().map(o => o.label)).toEqual(['All', 'Top 4', 'Bottom 2']);
   });
 
   it('formats the goal difference with an explicit sign', () => {

--- a/src/main/webapp/src/app/component/standings/standings.component.ts
+++ b/src/main/webapp/src/app/component/standings/standings.component.ts
@@ -1,10 +1,9 @@
 import {Component, OnInit, computed, inject, signal, ChangeDetectionStrategy} from '@angular/core';
 import {Standing} from '../../model/standing';
 import {TeamService} from '../../service/team.service';
+import {ConfigurationService} from '../../service/configuration.service';
 import {TeamPillComponent} from '../common/team-pill/team-pill.component';
 import {SegComponent, SegOption} from '../common/seg/seg.component';
-
-const NUMBER_OF_EDGE_TEAMS = 3;
 
 export type StandingsFilter = 'all' | 'top' | 'bottom';
 
@@ -19,8 +18,8 @@ interface StandingRow {
  *
  * The whole table (order, points, place, P/W/D/L/GF/GA and the "after queue N"
  * subtitle) comes from /api/teams/standings — nothing is derived client-side anymore.
- * Top 3 = accent zone, bottom 3 = danger, matching the dashboard widget's
- * NUMBER_OF_EDGE_TEAMS.
+ * Zone sizes follow NUMBER_OF_EDGE_TEAMS from the backend configuration (top edge =
+ * accent, bottom edge = danger), matching the dashboard widget.
  */
 @Component({
   selector: 'app-standings',
@@ -31,22 +30,27 @@ interface StandingRow {
 })
 export class StandingsComponent implements OnInit {
   private readonly teamService = inject(TeamService);
+  private readonly configurationService = inject(ConfigurationService);
+
+  /** Edge-zone size (NUMBER_OF_EDGE_TEAMS) from the backend configuration. */
+  readonly edgeTeams = this.configurationService.edgeTeams;
 
   readonly standings = signal<Standing[]>([]);
   readonly afterQueue = signal<number | null>(null);
   readonly filter = signal<StandingsFilter>('all');
 
-  readonly filterOptions: SegOption<StandingsFilter>[] = [
+  readonly filterOptions = computed<SegOption<StandingsFilter>[]>(() => [
     {value: 'all', label: 'All'},
-    {value: 'top', label: `Top ${NUMBER_OF_EDGE_TEAMS * 2}`},
-    {value: 'bottom', label: `Bottom ${NUMBER_OF_EDGE_TEAMS}`}
-  ];
+    {value: 'top', label: `Top ${this.edgeTeams() * 2}`},
+    {value: 'bottom', label: `Bottom ${this.edgeTeams()}`}
+  ]);
 
   readonly rows = computed<StandingRow[]>(() => {
     const total = this.standings().length;
+    const edge = this.edgeTeams();
     return this.standings().map(standing => {
-      const zone = standing.place <= NUMBER_OF_EDGE_TEAMS ? 'accent' as const
-        : (standing.place > total - NUMBER_OF_EDGE_TEAMS && total >= NUMBER_OF_EDGE_TEAMS * 2) ? 'danger' as const
+      const zone = standing.place <= edge ? 'accent' as const
+        : (standing.place > total - edge && total >= edge * 2) ? 'danger' as const
         : null;
       return {standing, zone};
     });
@@ -55,10 +59,11 @@ export class StandingsComponent implements OnInit {
   readonly visibleRows = computed(() => {
     const filter = this.filter();
     const total = this.rows().length;
+    const edge = this.edgeTeams();
     return this.rows().filter(row =>
       filter === 'all' ? true
-        : filter === 'top' ? row.standing.place <= NUMBER_OF_EDGE_TEAMS * 2
-        : row.standing.place > total - NUMBER_OF_EDGE_TEAMS);
+        : filter === 'top' ? row.standing.place <= edge * 2
+        : row.standing.place > total - edge);
   });
 
   readonly maxPoints = computed(() => {
@@ -67,6 +72,7 @@ export class StandingsComponent implements OnInit {
   });
 
   ngOnInit(): void {
+    this.configurationService.ensureEdgeTeamsLoaded();
     this.teamService.getStandings().subscribe(standings => {
       this.standings.set(standings.rows);
       this.afterQueue.set(standings.afterQueue);

--- a/src/main/webapp/src/app/service/configuration.service.spec.ts
+++ b/src/main/webapp/src/app/service/configuration.service.spec.ts
@@ -2,7 +2,7 @@ import {TestBed} from '@angular/core/testing';
 import {HttpErrorResponse, provideHttpClient, withInterceptors} from '@angular/common/http';
 import {HttpTestingController, provideHttpClientTesting} from '@angular/common/http/testing';
 
-import {ConfigurationService} from './configuration.service';
+import {ConfigurationService, DEFAULT_NUMBER_OF_EDGE_TEAMS} from './configuration.service';
 import {ToastService} from './toast.service';
 import {httpErrorInterceptor} from './http-error.interceptor';
 import {Config} from '../model/config';
@@ -83,5 +83,55 @@ describe('ConfigurationService', () => {
 
     expect(error?.status).toBe(500);
     expect(toastService.toast()).toEqual({message: 'Request failed (HTTP 500)', kind: 'error'});
+  });
+
+  describe('edgeTeams', () => {
+    it('starts on the fallback before any fetch', () => {
+      expect(service.edgeTeams()).toBe(DEFAULT_NUMBER_OF_EDGE_TEAMS);
+    });
+
+    it('loads NUMBER_OF_EDGE_TEAMS once and ignores repeat calls', () => {
+      service.ensureEdgeTeamsLoaded();
+      httpTesting.expectOne(configurationUrl)
+        .flush([{id: 2, name: 'NUMBER_OF_EDGE_TEAMS', value: 4.0, group: 'difficulty'}]);
+
+      expect(service.edgeTeams()).toBe(4);
+
+      service.ensureEdgeTeamsLoaded();
+      httpTesting.expectNone(configurationUrl);
+    });
+
+    it('retries on a later call after the fetch fails, keeping the fallback meanwhile', () => {
+      service.ensureEdgeTeamsLoaded();
+      httpTesting.expectOne(configurationUrl)
+        .flush(null, {status: 500, statusText: 'Internal Server Error'});
+      expect(service.edgeTeams()).toBe(DEFAULT_NUMBER_OF_EDGE_TEAMS);
+
+      service.ensureEdgeTeamsLoaded();
+      httpTesting.expectOne(configurationUrl)
+        .flush([{id: 2, name: 'NUMBER_OF_EDGE_TEAMS', value: 5.0, group: 'difficulty'}]);
+      expect(service.edgeTeams()).toBe(5);
+    });
+
+    it('keeps the current value when the key is missing or not positive', () => {
+      service.ensureEdgeTeamsLoaded();
+      httpTesting.expectOne(configurationUrl)
+        .flush([{id: 1, name: 'AVERAGE_GRADE_MULTIPLIER', value: 10, group: 'potential'}]);
+      expect(service.edgeTeams()).toBe(DEFAULT_NUMBER_OF_EDGE_TEAMS);
+
+      service.update(configs).subscribe();
+      httpTesting.expectOne(configurationUrl)
+        .flush([{id: 2, name: 'NUMBER_OF_EDGE_TEAMS', value: 0, group: 'difficulty'}]);
+      expect(service.edgeTeams()).toBe(DEFAULT_NUMBER_OF_EDGE_TEAMS);
+    });
+
+    it('stays in sync when the configuration screen saves a new value', () => {
+      const updated: Config[] = [{id: 2, name: 'NUMBER_OF_EDGE_TEAMS', value: 2.0, group: 'difficulty'}];
+
+      service.update(updated).subscribe();
+      httpTesting.expectOne(configurationUrl).flush(updated);
+
+      expect(service.edgeTeams()).toBe(2);
+    });
   });
 });

--- a/src/main/webapp/src/app/service/configuration.service.spec.ts
+++ b/src/main/webapp/src/app/service/configuration.service.spec.ts
@@ -101,6 +101,16 @@ describe('ConfigurationService', () => {
       httpTesting.expectNone(configurationUrl);
     });
 
+    it('skips the fetch when the configuration was already loaded elsewhere', () => {
+      service.findAll().subscribe();
+      httpTesting.expectOne(configurationUrl)
+        .flush([{id: 2, name: 'NUMBER_OF_EDGE_TEAMS', value: 4.0, group: 'difficulty'}]);
+
+      service.ensureEdgeTeamsLoaded();
+      httpTesting.expectNone(configurationUrl);
+      expect(service.edgeTeams()).toBe(4);
+    });
+
     it('retries on a later call after the fetch fails, keeping the fallback meanwhile', () => {
       service.ensureEdgeTeamsLoaded();
       httpTesting.expectOne(configurationUrl)

--- a/src/main/webapp/src/app/service/configuration.service.ts
+++ b/src/main/webapp/src/app/service/configuration.service.ts
@@ -1,8 +1,11 @@
-import { Injectable, inject } from '@angular/core';
+import { Injectable, inject, signal } from '@angular/core';
 import { HttpClient, HttpHeaders } from "@angular/common/http";
-import {Observable} from "rxjs";
+import {Observable, tap} from "rxjs";
 import {Config} from "../model/config";
 import {environment} from "../../environments/environment";
+
+/** Fallback until /api/configuration responds (also the seed value in data.sql). */
+export const DEFAULT_NUMBER_OF_EDGE_TEAMS = 3;
 
 @Injectable({
   providedIn: 'root'
@@ -18,11 +21,42 @@ export class ConfigurationService {
     })
   };
 
+  private readonly edgeTeamsSignal = signal(DEFAULT_NUMBER_OF_EDGE_TEAMS);
+  /**
+   * NUMBER_OF_EDGE_TEAMS from the backend configuration — the size of the top / bottom
+   * edges of the table. Consumers derive zones and flags from this instead of a local
+   * hardcode, so the UI follows the configurable server-side value.
+   */
+  readonly edgeTeams = this.edgeTeamsSignal.asReadonly();
+  private edgeTeamsLoaded = false;
+
+  /**
+   * One-shot lazy fetch of the configuration to populate {@link edgeTeams}. Idempotent —
+   * every screen that derives edge zones calls this on init and only the first call hits
+   * the backend. On error the fallback stays and the next call retries.
+   */
+  public ensureEdgeTeamsLoaded(): void {
+    if (this.edgeTeamsLoaded) return;
+    this.edgeTeamsLoaded = true;
+    this.findAll().subscribe({
+      error: () => this.edgeTeamsLoaded = false
+    });
+  }
+
   public update(config: Config[]): Observable<Config[]> {
     return this.http.put<Config[]>(this.configurationUrl, config)
+      .pipe(tap(configs => this.syncEdgeTeams(configs)))
   }
 
   public findAll(): Observable<Config[]> {
     return this.http.get<Config[]>(this.configurationUrl)
+      .pipe(tap(configs => this.syncEdgeTeams(configs)))
+  }
+
+  private syncEdgeTeams(configs: Config[]): void {
+    const value = configs.find(c => c.name === 'NUMBER_OF_EDGE_TEAMS')?.value;
+    if (value != null && value > 0) {
+      this.edgeTeamsSignal.set(Math.round(value));
+    }
   }
 }

--- a/src/main/webapp/src/app/service/configuration.service.ts
+++ b/src/main/webapp/src/app/service/configuration.service.ts
@@ -54,6 +54,9 @@ export class ConfigurationService {
   }
 
   private syncEdgeTeams(configs: Config[]): void {
+    // Any successful configuration response counts as "loaded" — e.g. the Configuration
+    // screen calling findAll() directly spares ensureEdgeTeamsLoaded() a duplicate fetch.
+    this.edgeTeamsLoaded = true;
     const value = configs.find(c => c.name === 'NUMBER_OF_EDGE_TEAMS')?.value;
     if (value != null && value > 0) {
       this.edgeTeamsSignal.set(Math.round(value));


### PR DESCRIPTION
## Ticket

[RS-84 — NUMBER_OF_EDGE_TEAMS z API zamiast hardcode w 4 komponentach](https://referee-staffer.youtrack.cloud/issue/RS-84)

The frontend had `NUMBER_OF_EDGE_TEAMS = 3` hardcoded as a module-level const in four components (dashboard, staffer, match-detail, standings), while the backend keeps the value configurable in the `config` table and exposes it via `GET /api/configuration`. Any change of the config on the Configuration screen would silently desynchronize the locally derived zones/flags from the server-side computation. After RS-27 (#83) the `place` values come from the backend (`StandingsDto` rows), but the zone *thresholds* were still derived from the duplicated local constant — this PR removes that last local derivation.

## Plan

1. **`ConfigurationService`** — add an `edgeTeams` signal (fallback `3`, matching the `data.sql` seed) plus an idempotent `ensureEdgeTeamsLoaded()` that fetches `/api/configuration` once ("jeden strzał, w serwisie z sygnałem" per the ticket). Additionally tap `findAll()`/`update()` responses so the signal stays in sync whenever the Configuration screen loads or saves.
2. **`dashboard`** — drop the local const; `zoneFor()` reads the signal; trigger the one-shot load in `ngOnInit`.
3. **`standings`** — drop the const; `filterOptions` becomes a `computed` so the "Top N / Bottom N" segment labels follow the config; zone math on the backend-provided `place` reads the signal; load in `ngOnInit`.
4. **`match-detail`** — the local fallbacks in `isTopMatch`/`isRelegationMatch` (used only until the backend breakdown lands) read the signal; load in `ngOnInit`.
5. **`staffer`** — `flags()` reads the signal; load in the constructor (the screen fetches its data lazily on Generate, but the flag derivation is local).
6. Make the hardcoded "top-3" chip/row labels in the staffer and match-detail templates follow the configured value.
7. Tests: extend the service spec and the component specs with a `ConfigurationService` stub and tests proving zones/labels follow the configured value.

## Changes

- `ConfigurationService`: new exported `DEFAULT_NUMBER_OF_EDGE_TEAMS = 3` fallback, readonly `edgeTeams` signal, `ensureEdgeTeamsLoaded()` (one-shot; a failed fetch keeps the fallback and retries on the next call; any successful `findAll()`/`update()` — e.g. from the Configuration screen — counts as loaded, so no duplicate request), and a private `syncEdgeTeams()` applied via `tap` on both `findAll()` and `update()`. Values are `Math.round`-ed (backend stores doubles) and non-positive/missing values are ignored so a bad config can't break the UI.
- All four components inject the service, expose `readonly edgeTeams` for their templates, and derive zones/flags from it instead of a module const. Load is triggered from `ngOnInit` (dashboard, standings, match-detail) or the constructor (staffer).
- Templates: standings binds `filterOptions()` (now a computed); "top-3" chip and "Top-3 match" breakdown-row labels in staffer/match-detail render `top-{{ edgeTeams() }}`.
- Design decisions: kept the signal in the existing `ConfigurationService` rather than adding a new service; lazy idempotent load from consumers instead of an eager app-bootstrap fetch; non-blocking fetch — components render immediately with the fallback and re-derive when the response lands (signals propagate automatically).
- **Rebased onto master after RS-27 (#83), RS-79 (Angular 22), RS-85, RS-89 and RS-80 landed.** Zone math in standings/staffer/match-detail now uses the backend-provided `place` from `StandingsDto` rows (RS-27) with only the threshold coming from the config signal. The RS-89 specs for dashboard/match-detail and the RS-80 `configuration.service.spec.ts` gained the `ConfigurationService` stub / `edgeTeams` test block instead of introducing parallel spec files.
- Scope note: the RS-84 ticket also mentions the alternative of returning ready zone flags in `StandingsDto` rows. The config-signal approach was kept because the edge size is needed beyond the standings rows anyway — for the staffer/match-detail local flag fallbacks and for the "Top N / Bottom N / top-N" labels — so a single shared signal covers all four screens without a backend change.

## Testing

- `configuration.service.spec.ts` (on top of the RS-80 spec): fallback before fetch, one-shot + idempotence, skip when already loaded elsewhere, retry after error, ignoring missing/non-positive values, sync on `update()`.
- Component specs (`standings`, `staffer`, `dashboard`, `match-detail`): stubbed `ConfigurationService` (writable signal, same pattern as the `UiSettingsService` stub) + new tests that zones, filter labels and flag fallbacks follow a changed edge size (set to 2).
- `npm run lint` — clean; `npm test` (ChromeHeadlessNoSandbox, Node 26.5.1) — 258/258 green; `npm run build` (Angular 22 esbuild, production) — passes.

🤖 Generated with Claude Code