### PR TITLE
RS-8: Generate referee assignment PDF for a queue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <openapi.version>3.0.3</openapi.version>
         <groovy.version>5.0.6</groovy.version>
         <spock.version>2.4-groovy-5.0</spock.version>
+        <openpdf.version>3.0.5</openpdf.version>
         <jacoco.version>0.8.15</jacoco.version>
         <!-- Toggle to skip the frontend build. Useful for backend-only CI jobs.
              Override with -DskipFrontend=true. -->
@@ -52,6 +53,13 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
+        </dependency>
+
+        <!-- PDF generation (assignment sheets) -->
+        <dependency>
+            <groupId>com.github.librepdf</groupId>
+            <artifactId>openpdf</artifactId>
+            <version>${openpdf.version}</version>
         </dependency>
 
         <!-- Swagger -->

--- a/src/main/java/com/jamex/refereestaffer/controller/MatchController.java
+++ b/src/main/java/com/jamex/refereestaffer/controller/MatchController.java
@@ -5,9 +5,14 @@ import com.jamex.refereestaffer.model.dto.DifficultyBreakdownDto;
 import com.jamex.refereestaffer.model.dto.MatchDto;
 import com.jamex.refereestaffer.model.exception.MatchNotFoundException;
 import com.jamex.refereestaffer.repository.MatchRepository;
+import com.jamex.refereestaffer.service.AssignmentPdfService;
 import com.jamex.refereestaffer.service.MatchService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,11 +34,14 @@ public class MatchController {
     private final MatchRepository matchRepository;
     private final MatchConverter matchConverter;
     private final MatchService matchService;
+    private final AssignmentPdfService assignmentPdfService;
 
-    public MatchController(MatchRepository matchRepository, MatchConverter matchConverter, MatchService matchService) {
+    public MatchController(MatchRepository matchRepository, MatchConverter matchConverter, MatchService matchService,
+                           AssignmentPdfService assignmentPdfService) {
         this.matchRepository = matchRepository;
         this.matchConverter = matchConverter;
         this.matchService = matchService;
+        this.assignmentPdfService = assignmentPdfService;
     }
 
     @GetMapping
@@ -59,6 +67,23 @@ public class MatchController {
     public DifficultyBreakdownDto getMatchDifficulty(@PathVariable Long id) {
         log.info("Computing difficulty breakdown for match {}", id);
         return matchService.computeDifficultyBreakdown(id);
+    }
+
+    /**
+     * Assignment sheet for a queue as a downloadable PDF (RS-8). Renders persisted
+     * assignments — save the cast on the Staffer screen first for it to show up here.
+     */
+    @GetMapping("/queue/{queue}/pdf")
+    public ResponseEntity<byte[]> getAssignmentsPdf(@PathVariable short queue) {
+        log.info("Generating assignment PDF for queue {}", queue);
+        var pdf = assignmentPdfService.generateAssignmentsPdf(queue);
+        var contentDisposition = ContentDisposition.attachment()
+                .filename("referee-assignments-queue-" + queue + ".pdf")
+                .build();
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_PDF)
+                .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition.toString())
+                .body(pdf);
     }
 
     @PostMapping

--- a/src/main/java/com/jamex/refereestaffer/model/exception/MatchNotFoundException.java
+++ b/src/main/java/com/jamex/refereestaffer/model/exception/MatchNotFoundException.java
@@ -3,8 +3,13 @@ package com.jamex.refereestaffer.model.exception;
 public class MatchNotFoundException extends RuntimeException {
 
     public static final String NOT_FOUND = "Match with id = %d has not been found";
+    public static final String QUEUE_EMPTY = "No matches have been found for queue = %d";
 
     public MatchNotFoundException(Long id) {
         super(String.format(NOT_FOUND, id));
+    }
+
+    public MatchNotFoundException(short queue) {
+        super(String.format(QUEUE_EMPTY, queue));
     }
 }

--- a/src/main/java/com/jamex/refereestaffer/repository/MatchRepository.java
+++ b/src/main/java/com/jamex/refereestaffer/repository/MatchRepository.java
@@ -15,5 +15,7 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
 
     List<Match> findAllByQueueAndRefereeIsNull(Short queue);
 
+    List<Match> findAllByQueueOrderByDateAsc(Short queue);
+
     List<Match> findAllByHomeScoreNotNullAndAwayScoreNotNull();
 }

--- a/src/main/java/com/jamex/refereestaffer/service/AssignmentPdfService.java
+++ b/src/main/java/com/jamex/refereestaffer/service/AssignmentPdfService.java
@@ -1,0 +1,126 @@
+package com.jamex.refereestaffer.service;
+
+import com.jamex.refereestaffer.model.entity.Match;
+import com.jamex.refereestaffer.model.entity.Team;
+import com.jamex.refereestaffer.model.exception.MatchNotFoundException;
+import com.jamex.refereestaffer.repository.MatchRepository;
+import org.openpdf.text.Document;
+import org.openpdf.text.DocumentException;
+import org.openpdf.text.Element;
+import org.openpdf.text.Font;
+import org.openpdf.text.PageSize;
+import org.openpdf.text.Paragraph;
+import org.openpdf.text.Phrase;
+import org.openpdf.text.pdf.BaseFont;
+import org.openpdf.text.pdf.PdfPCell;
+import org.openpdf.text.pdf.PdfPTable;
+import org.openpdf.text.pdf.PdfWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.awt.Color;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * Renders the referee assignment sheet for a queue as a PDF — the printable/mailable
+ * counterpart of the Staffer screen's cast table. Reads whatever is persisted, so the
+ * sheet reflects the last saved cast, not unsaved edits in the UI.
+ */
+@Service
+public class AssignmentPdfService {
+
+    private static final Logger log = LoggerFactory.getLogger(AssignmentPdfService.class);
+
+    static final String UNASSIGNED = "unassigned";
+
+    /** Matches the date format of the CSV importer, so sheets read like the source data. */
+    private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm");
+    private static final Color HEADER_BACKGROUND = new Color(240, 240, 240);
+    private static final Color MUTED_TEXT = new Color(120, 120, 120);
+
+    private final MatchRepository matchRepository;
+
+    public AssignmentPdfService(MatchRepository matchRepository) {
+        this.matchRepository = matchRepository;
+    }
+
+    public byte[] generateAssignmentsPdf(short queue) {
+        var matches = matchRepository.findAllByQueueOrderByDateAsc(queue);
+        if (matches.isEmpty()) {
+            throw new MatchNotFoundException(queue);
+        }
+        log.info("Rendering assignment PDF for queue {} with {} matches", queue, matches.size());
+        return render(queue, matches);
+    }
+
+    private byte[] render(short queue, List<Match> matches) {
+        try {
+            // Cp1250 (Central European) instead of the default Cp1252 — team and referee
+            // names imported from the CSV carry Polish diacritics.
+            var baseFont = BaseFont.createFont(BaseFont.HELVETICA, BaseFont.CP1250, BaseFont.NOT_EMBEDDED);
+            var boldFont = BaseFont.createFont(BaseFont.HELVETICA_BOLD, BaseFont.CP1250, BaseFont.NOT_EMBEDDED);
+            var title = new Font(boldFont, 16);
+            var subtitle = new Font(baseFont, 9, Font.NORMAL, MUTED_TEXT);
+            var tableHeader = new Font(boldFont, 10);
+            var cell = new Font(baseFont, 10);
+            var mutedCell = new Font(baseFont, 10, Font.ITALIC, MUTED_TEXT);
+
+            var out = new ByteArrayOutputStream();
+            var document = new Document(PageSize.A4, 36, 36, 42, 36);
+            PdfWriter.getInstance(document, out);
+            document.open();
+
+            var heading = new Paragraph("Referee assignments - Queue " + queue, title);
+            document.add(heading);
+            var generatedAt = new Paragraph("Generated on " + LocalDateTime.now().format(DATE_TIME_FORMAT), subtitle);
+            generatedAt.setSpacingAfter(14);
+            document.add(generatedAt);
+
+            var table = new PdfPTable(new float[]{0.7f, 2.2f, 3f, 3f, 3f});
+            table.setWidthPercentage(100);
+            table.setHeaderRows(1);
+            for (var header : List.of("#", "Date", "Home", "Away", "Referee")) {
+                var headerCell = new PdfPCell(new Phrase(header, tableHeader));
+                headerCell.setBackgroundColor(HEADER_BACKGROUND);
+                headerCell.setPadding(6);
+                table.addCell(headerCell);
+            }
+
+            var index = 1;
+            for (var match : matches) {
+                table.addCell(bodyCell(String.valueOf(index++), cell));
+                table.addCell(bodyCell(match.getDate().format(DATE_TIME_FORMAT), cell));
+                table.addCell(bodyCell(teamName(match.getHome()), cell));
+                table.addCell(bodyCell(teamName(match.getAway()), cell));
+                var referee = match.getReferee();
+                table.addCell(referee == null
+                        ? bodyCell(UNASSIGNED, mutedCell)
+                        : bodyCell(referee.getFirstName() + " " + referee.getLastName(), cell));
+            }
+            document.add(table);
+            document.close();
+
+            return out.toByteArray();
+        } catch (DocumentException | IOException e) {
+            // BaseFont.createFont declares IOException, but built-in fonts never touch disk —
+            // any failure here is a programming error, not a recoverable condition.
+            throw new IllegalStateException("Failed to render assignment PDF for queue " + queue, e);
+        }
+    }
+
+    private PdfPCell bodyCell(String text, Font font) {
+        var pdfCell = new PdfPCell(new Phrase(text, font));
+        pdfCell.setPadding(6);
+        pdfCell.setVerticalAlignment(Element.ALIGN_MIDDLE);
+        return pdfCell;
+    }
+
+    private String teamName(Team team) {
+        return team == null ? "-" : team.getName();
+    }
+}

--- a/src/main/webapp/src/app/component/staffer/staffer.component.html
+++ b/src/main/webapp/src/app/component/staffer/staffer.component.html
@@ -16,6 +16,11 @@
     <button type="button" class="btn" (click)="clearLocks()" [disabled]="lockCount() === 0">
       Clear locks
     </button>
+    <button type="button" class="btn" (click)="exportPdf()" [disabled]="exporting()"
+            title="Download the saved cast for this queue as a PDF">
+      <app-icon name="download" [size]="12"></app-icon>
+      {{ exporting() ? 'Exporting…' : 'Export PDF' }}
+    </button>
     <button type="button" class="btn btn--primary" (click)="generate()" [disabled]="loading()">
       <app-icon name="play" [size]="12"></app-icon>
       {{ loading() ? 'Generating…' : 'Generate cast' }}

--- a/src/main/webapp/src/app/component/staffer/staffer.component.spec.ts
+++ b/src/main/webapp/src/app/component/staffer/staffer.component.spec.ts
@@ -89,7 +89,8 @@ describe('StafferComponent', () => {
     stafferService = jasmine.createSpyObj('StafferService', ['staffReferees']);
     teamService = jasmine.createSpyObj('TeamService', ['getStandings']);
     refereeService = jasmine.createSpyObj('RefereeService', ['findRefereesAvailableForQueue']);
-    matchService = jasmine.createSpyObj('MatchService', ['getDifficultyBreakdown', 'updateList']);
+    matchService = jasmine.createSpyObj('MatchService',
+      ['getDifficultyBreakdown', 'updateList', 'downloadAssignmentsPdf']);
     explainerVisible = signal(false);
 
     stafferService.staffReferees.and.returnValue(of(matches));
@@ -362,6 +363,56 @@ describe('StafferComponent', () => {
 
       expect(matchService.updateList).not.toHaveBeenCalled();
       expect(component.savedAt()).toBeNull();
+    });
+  });
+
+  describe('exportPdf', () => {
+    let createdAnchor: HTMLAnchorElement;
+
+    beforeEach(() => {
+      matchService.downloadAssignmentsPdf.and.returnValue(of(new Blob(['%PDF-'], {type: 'application/pdf'})));
+      spyOn(URL, 'createObjectURL').and.returnValue('blob:fake');
+      spyOn(URL, 'revokeObjectURL');
+      const realCreateElement = document.createElement.bind(document);
+      spyOn(document, 'createElement').and.callFake((tag: string) => {
+        const el = realCreateElement(tag);
+        if (tag === 'a') {
+          createdAnchor = el as HTMLAnchorElement;
+          spyOn(createdAnchor, 'click');
+        }
+        return el;
+      });
+    });
+
+    it('downloads the PDF for the selected queue and triggers a browser download', () => {
+      component.incQueue();
+
+      component.exportPdf();
+
+      expect(matchService.downloadAssignmentsPdf).toHaveBeenCalledWith(2);
+      expect(createdAnchor.download).toBe('referee-assignments-queue-2.pdf');
+      expect(createdAnchor.click).toHaveBeenCalled();
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:fake');
+      expect(component.exporting()).toBeFalse();
+    });
+
+    it('keeps exporting true until the download completes', () => {
+      const pdfSubject = new Subject<Blob>();
+      matchService.downloadAssignmentsPdf.and.returnValue(pdfSubject);
+
+      component.exportPdf();
+      expect(component.exporting()).toBeTrue();
+
+      pdfSubject.next(new Blob());
+      expect(component.exporting()).toBeFalse();
+    });
+
+    it('clears the exporting flag on error', () => {
+      matchService.downloadAssignmentsPdf.and.returnValue(throwError(() => new Error('empty queue')));
+
+      component.exportPdf();
+
+      expect(component.exporting()).toBeFalse();
     });
   });
 

--- a/src/main/webapp/src/app/component/staffer/staffer.component.ts
+++ b/src/main/webapp/src/app/component/staffer/staffer.component.ts
@@ -76,6 +76,7 @@ export class StafferComponent {
   readonly drawerBreakdown = signal<DifficultyBreakdown | null>(null);
   readonly savedAt = signal<Date | null>(null);
   readonly loading = signal(false);
+  readonly exporting = signal(false);
 
   // ——— Derived state ———
 
@@ -136,6 +137,29 @@ export class StafferComponent {
         this.loading.set(false);
       },
       error: () => this.loading.set(false)
+    });
+  }
+
+  /**
+   * Downloads the assignment sheet PDF for the selected queue. The backend renders
+   * persisted assignments, so unsaved edits (swaps not yet saved) are not included.
+   */
+  exportPdf(): void {
+    this.exporting.set(true);
+    this.matchService.downloadAssignmentsPdf(this.queue()).subscribe({
+      next: blob => {
+        const url = URL.createObjectURL(blob);
+        const anchor = document.createElement('a');
+        anchor.href = url;
+        anchor.download = `referee-assignments-queue-${this.queue()}.pdf`;
+        // Firefox needs the anchor in the DOM for a programmatic download click.
+        document.body.appendChild(anchor);
+        anchor.click();
+        anchor.remove();
+        URL.revokeObjectURL(url);
+        this.exporting.set(false);
+      },
+      error: () => this.exporting.set(false)
     });
   }
 

--- a/src/main/webapp/src/app/service/http-error.interceptor.spec.ts
+++ b/src/main/webapp/src/app/service/http-error.interceptor.spec.ts
@@ -1,0 +1,91 @@
+import {TestBed} from '@angular/core/testing';
+import {HttpClient, provideHttpClient, withInterceptors} from '@angular/common/http';
+import {HttpTestingController, provideHttpClientTesting} from '@angular/common/http/testing';
+import {httpErrorInterceptor} from './http-error.interceptor';
+import {ToastService} from './toast.service';
+
+describe('httpErrorInterceptor', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+  let toastService: jasmine.SpyObj<ToastService>;
+
+  beforeEach(() => {
+    toastService = jasmine.createSpyObj('ToastService', ['show']);
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([httpErrorInterceptor])),
+        provideHttpClientTesting(),
+        {provide: ToastService, useValue: toastService}
+      ]
+    });
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  // Blob.text() resolves outside Angular's zone, so poll briefly instead of a fixed sleep.
+  async function waitForToast(): Promise<void> {
+    for (let i = 0; i < 50 && toastService.show.calls.count() === 0; i++) {
+      await new Promise(resolve => setTimeout(resolve, 1));
+    }
+  }
+
+  it('shows the ProblemDetail detail for JSON error responses', () => {
+    http.get('/api/things/1').subscribe({error: () => undefined});
+
+    httpMock.expectOne('/api/things/1')
+      .flush({detail: 'Match with id = 1 has not been found'}, {status: 404, statusText: 'Not Found'});
+
+    expect(toastService.show).toHaveBeenCalledWith('Match with id = 1 has not been found', 'error');
+  });
+
+  it('shows a connectivity message when the server is unreachable', () => {
+    http.get('/api/things').subscribe({error: () => undefined});
+
+    httpMock.expectOne('/api/things').error(new ProgressEvent('error'), {status: 0});
+
+    expect(toastService.show).toHaveBeenCalledWith('Cannot reach the server', 'error');
+  });
+
+  it('falls back to a generic message when there is no detail', () => {
+    http.get('/api/things').subscribe({error: () => undefined});
+
+    httpMock.expectOne('/api/things').flush('boom', {status: 500, statusText: 'Server Error'});
+
+    expect(toastService.show).toHaveBeenCalledWith('Request failed (HTTP 500)', 'error');
+  });
+
+  it('reads the ProblemDetail detail out of blob error responses', async () => {
+    http.get('/api/matches/queue/44/pdf', {responseType: 'blob'}).subscribe({error: () => undefined});
+    const problemJson = new Blob(
+      [JSON.stringify({detail: 'No matches have been found for queue = 44'})],
+      {type: 'application/problem+json'});
+
+    httpMock.expectOne('/api/matches/queue/44/pdf')
+      .flush(problemJson, {status: 404, statusText: 'Not Found'});
+    await waitForToast();
+
+    expect(toastService.show).toHaveBeenCalledWith('No matches have been found for queue = 44', 'error');
+  });
+
+  it('falls back to a generic message for a JSON-typed blob that is not valid JSON', async () => {
+    http.get('/api/matches/queue/44/pdf', {responseType: 'blob'}).subscribe({error: () => undefined});
+    const brokenBlob = new Blob(['not json'], {type: 'application/problem+json'});
+
+    httpMock.expectOne('/api/matches/queue/44/pdf')
+      .flush(brokenBlob, {status: 404, statusText: 'Not Found'});
+    await waitForToast();
+
+    expect(toastService.show).toHaveBeenCalledWith('Request failed (HTTP 404)', 'error');
+  });
+
+  it('rethrows the error so component callbacks still run', () => {
+    let caught: unknown;
+    http.get('/api/things').subscribe({error: err => caught = err});
+
+    httpMock.expectOne('/api/things').flush(null, {status: 500, statusText: 'Server Error'});
+
+    expect(caught).toBeDefined();
+  });
+});

--- a/src/main/webapp/src/app/service/http-error.interceptor.ts
+++ b/src/main/webapp/src/app/service/http-error.interceptor.ts
@@ -12,7 +12,15 @@ export const httpErrorInterceptor: HttpInterceptorFn = (req, next) => {
   const toastService = inject(ToastService);
   return next(req).pipe(
     catchError((error: HttpErrorResponse) => {
-      toastService.show(messageFor(error), 'error');
+      // Requests made with responseType 'blob' (PDF download) get their ProblemDetail
+      // wrapped in a Blob — read it asynchronously; the toast can arrive a tick late.
+      if (error.error instanceof Blob && error.error.type.includes('json')) {
+        error.error.text().then(
+          text => toastService.show(messageFromProblemJson(error, text), 'error'),
+          () => toastService.show(fallbackMessage(error), 'error'));
+      } else {
+        toastService.show(messageFor(error), 'error');
+      }
       return throwError(() => error);
     })
   );
@@ -28,5 +36,21 @@ function messageFor(error: HttpErrorResponse): string {
   if (typeof detail === 'string' && detail.length > 0) {
     return detail;
   }
+  return fallbackMessage(error);
+}
+
+function messageFromProblemJson(error: HttpErrorResponse, text: string): string {
+  try {
+    const detail = JSON.parse(text)?.detail;
+    if (typeof detail === 'string' && detail.length > 0) {
+      return detail;
+    }
+  } catch {
+    // fall through — not valid JSON after all
+  }
+  return fallbackMessage(error);
+}
+
+function fallbackMessage(error: HttpErrorResponse): string {
   return `Request failed (HTTP ${error.status})`;
 }

--- a/src/main/webapp/src/app/service/match.service.ts
+++ b/src/main/webapp/src/app/service/match.service.ts
@@ -41,4 +41,8 @@ export class MatchService {
   public getDifficultyBreakdown(matchId: number): Observable<DifficultyBreakdown> {
     return this.http.get<DifficultyBreakdown>(`${this.matchesUrl}/${matchId}/difficulty`)
   }
+
+  public downloadAssignmentsPdf(queue: number): Observable<Blob> {
+    return this.http.get(`${this.matchesUrl}/queue/${queue}/pdf`, {responseType: 'blob'})
+  }
 }

--- a/src/test/groovy/com/jamex/refereestaffer/controller/MatchControllerSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/controller/MatchControllerSpec.groovy
@@ -6,6 +6,7 @@ import com.jamex.refereestaffer.model.dto.MatchDto
 import com.jamex.refereestaffer.model.entity.Match
 import com.jamex.refereestaffer.model.exception.MatchNotFoundException
 import com.jamex.refereestaffer.repository.MatchRepository
+import com.jamex.refereestaffer.service.AssignmentPdfService
 import com.jamex.refereestaffer.service.MatchService
 import groovy.json.JsonSlurper
 import org.spockframework.runtime.model.parallel.ExecutionMode
@@ -39,6 +40,9 @@ class MatchControllerSpec extends Specification {
 
     @SpringBean
     MatchService matchService = Mock()
+
+    @SpringBean
+    AssignmentPdfService assignmentPdfService = Mock()
 
     def "should return matches"() {
         given:
@@ -128,6 +132,36 @@ class MatchControllerSpec extends Specification {
         then:
         1 * matchService.computeDifficultyBreakdown(matchId) >> { throw new MatchNotFoundException(matchId) }
         response.status == 404
+    }
+
+    def "should download assignment PDF for queue"() {
+        given:
+        def queue = 5 as short
+        def pdfBytes = "%PDF-fake".bytes
+
+        when:
+        def response = mockMvc.perform(get("/api/matches/queue/$queue/pdf")).andReturn().response
+
+        then:
+        1 * assignmentPdfService.generateAssignmentsPdf(queue) >> pdfBytes
+        response.status == 200
+        response.contentType == MediaType.APPLICATION_PDF_VALUE
+        response.getHeader("Content-Disposition") == 'attachment; filename="referee-assignments-queue-5.pdf"'
+        response.contentAsByteArray == pdfBytes
+    }
+
+    def "should respond 404 with problem detail when queue has no matches to export"() {
+        given:
+        def queue = 44 as short
+
+        when:
+        def response = mockMvc.perform(get("/api/matches/queue/$queue/pdf")).andReturn().response
+
+        then:
+        1 * assignmentPdfService.generateAssignmentsPdf(queue) >> { throw new MatchNotFoundException(queue) }
+        response.status == 404
+        def json = new JsonSlurper().parseText(response.contentAsString)
+        json.detail == String.format(MatchNotFoundException.QUEUE_EMPTY, queue)
     }
 
     def "should create match and return it as JSON"() {

--- a/src/test/groovy/com/jamex/refereestaffer/service/AssignmentPdfServiceSpec.groovy
+++ b/src/test/groovy/com/jamex/refereestaffer/service/AssignmentPdfServiceSpec.groovy
@@ -1,0 +1,89 @@
+package com.jamex.refereestaffer.service
+
+import com.jamex.refereestaffer.model.entity.Match
+import com.jamex.refereestaffer.model.entity.Referee
+import com.jamex.refereestaffer.model.entity.Team
+import com.jamex.refereestaffer.model.exception.MatchNotFoundException
+import com.jamex.refereestaffer.repository.MatchRepository
+import org.openpdf.text.pdf.PdfReader
+import org.openpdf.text.pdf.parser.PdfTextExtractor
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.time.LocalDateTime
+
+class AssignmentPdfServiceSpec extends Specification {
+
+    MatchRepository matchRepository = Mock()
+
+    @Subject
+    AssignmentPdfService assignmentPdfService = new AssignmentPdfService(matchRepository)
+
+    def "should render a PDF listing every match of the queue with its referee"() {
+        given:
+        def queue = 3 as short
+        def matches = [
+                match(1l, "Wisła", "Cracovia", LocalDateTime.of(2026, 3, 1, 12, 30), referee("Sędzia", "Główny")),
+                match(2l, "Lech", "Warta", LocalDateTime.of(2026, 3, 2, 17, 0), null)
+        ]
+
+        when:
+        def pdf = assignmentPdfService.generateAssignmentsPdf(queue)
+
+        then:
+        1 * matchRepository.findAllByQueueOrderByDateAsc(queue) >> matches
+        new String(pdf, 0, 5) == "%PDF-"
+        def text = extractText(pdf)
+        text.contains("Referee assignments - Queue 3")
+        text.contains("Wisła")
+        text.contains("Cracovia")
+        text.contains("01.03.2026 12:30")
+        text.contains("Sędzia Główny")
+        text.contains("Lech")
+        text.contains("Warta")
+        text.contains(AssignmentPdfService.UNASSIGNED)
+    }
+
+    def "should throw when the queue has no matches"() {
+        given:
+        def queue = 44 as short
+
+        when:
+        assignmentPdfService.generateAssignmentsPdf(queue)
+
+        then:
+        1 * matchRepository.findAllByQueueOrderByDateAsc(queue) >> []
+        def ex = thrown(MatchNotFoundException)
+        ex.message == String.format(MatchNotFoundException.QUEUE_EMPTY, queue)
+    }
+
+    private static Match match(Long id, String homeName, String awayName, LocalDateTime date, Referee referee) {
+        Match.builder()
+                .id(id)
+                .queue(3 as Short)
+                .home(Team.builder().name(homeName).build())
+                .away(Team.builder().name(awayName).build())
+                .date(date)
+                .referee(referee)
+                .build()
+    }
+
+    private static Referee referee(String firstName, String lastName) {
+        Referee.builder()
+                .firstName(firstName)
+                .lastName(lastName)
+                .build()
+    }
+
+    private static String extractText(byte[] pdf) {
+        def reader = new PdfReader(pdf)
+        try {
+            def extractor = new PdfTextExtractor(reader)
+            (1..reader.numberOfPages)
+                    .collect { extractor.getTextFromPage(it) }
+                    .join("\n")
+        } finally {
+            reader.close()
+        }
+    }
+}


### PR DESCRIPTION
# Ticket

[RS-8 — Generate PDF with referee assignment to given queue](https://referee-staffer.youtrack.cloud/issue/RS-8)

The staffer produces a cast for a queue, but there was no way to hand it out — the assignments lived only on the Staffer screen. This adds a downloadable PDF assignment sheet for a given queue: the printable/mailable counterpart of the cast table, and the prerequisite for RS-9 (emailing the sheet to referees).

# Plan

1. Pick a PDF library: **OpenPDF 3.0.5** (`com.github.librepdf:openpdf`, `org.openpdf.*` packages) — actively maintained LGPL/MPL fork of iText 2, no transitive baggage, works on Java 25.
2. Backend rendering: new `AssignmentPdfService` that loads all matches of a queue sorted by date (new `MatchRepository.findAllByQueueOrderByDateAsc`) and renders an A4 sheet — title, generation timestamp, table of date / home / away / referee. Empty queue → 404 via a new queue-flavoured `MatchNotFoundException` constructor, reusing the existing `RestExceptionHandler` mapping.
3. Endpoint: `GET /api/matches/queue/{queue}/pdf` on `MatchController`, `application/pdf` with a `Content-Disposition: attachment` filename.
4. Frontend: `MatchService.downloadAssignmentsPdf` (blob GET) + an **Export PDF** button in the Staffer header that triggers a browser download for the selected queue.
5. Tests: Spock specs for the service (real PDF rendered, content asserted via `PdfTextExtractor`) and the controller slice (headers, body, 404), Jasmine specs for the component flow.

# Changes

- `pom.xml` — OpenPDF 3.0.5 dependency.
- `AssignmentPdfService` — renders the sheet. Design decisions:
  - **Cp1250 encoding** on built-in Helvetica: team/referee names imported from the CSV carry Polish diacritics (`Sędzia`, `Wisła`); the default Cp1252 would mangle them. Standard-14 fonts keep the PDF tiny (~2 KB) vs embedding a TTF.
  - Renders **persisted** assignments — the sheet reflects the last saved cast, not unsaved UI edits. Matches with no referee render as an italic `unassigned`.
  - Date format `dd.MM.yyyy HH:mm` mirrors the CSV importer's format.
- `MatchController.getAssignmentsPdf` — `GET /api/matches/queue/{queue}/pdf`, attachment filename `referee-assignments-queue-{queue}.pdf`; empty queue responds 404 ProblemDetail (surfaced by the frontend's global error toast).
- `MatchNotFoundException` — new `(short queue)` constructor with a `QUEUE_EMPTY` message.
- `MatchRepository` — `findAllByQueueOrderByDateAsc`.
- Staffer screen — **Export PDF** button (download icon, `Exporting…` busy state) in the header actions, next to Generate cast; downloads via a temporary object-URL anchor. Placed in the header (not the cast panel footer) so a previously saved cast can be exported without regenerating.
- `MatchService` (frontend) — blob GET for the endpoint.

# Testing

- **Backend** (`mvn -DskipFrontend=true test`): 134 tests green. `AssignmentPdfServiceSpec` renders a real PDF and asserts extracted text (title, teams with Polish diacritics, dates, referee name, `unassigned` fallback) plus the empty-queue 404 exception; `MatchControllerSpec` covers content type, `Content-Disposition`, body bytes and the 404 ProblemDetail.
- **Frontend** (`npm run lint`, `npm test` headless): lint clean, 140 tests green. New specs cover the download flow (service called with the selected queue, anchor download name, object-URL revocation, busy flag lifecycle, error path).
- Note: the sandbox has no JDK 25 preinstalled — backend tests ran on `openjdk-25-jdk-headless` installed via apt (same major as CI's Temurin 25).

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYeb9CdB1cJCuazMiVj7cL)_