### PR TITLE
RS-95: Add specs for ToastService, UiSettingsService and the logic-bearing atoms

### DIFF
--- a/src/main/webapp/src/app/component/common/ref-avatar/ref-avatar.component.spec.ts
+++ b/src/main/webapp/src/app/component/common/ref-avatar/ref-avatar.component.spec.ts
@@ -1,0 +1,76 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {RefAvatarComponent} from './ref-avatar.component';
+import {Referee} from '../../../model/referee';
+
+describe('RefAvatarComponent', () => {
+  const referee: Referee = {
+    id: 7,
+    firstName: 'Szymon',
+    lastName: 'Marciniak',
+    email: 'szymon.marciniak@example.com',
+    experience: 15
+  };
+
+  let fixture: ComponentFixture<RefAvatarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({imports: [RefAvatarComponent]}).compileComponents();
+    fixture = TestBed.createComponent(RefAvatarComponent);
+  });
+
+  function el(): HTMLElement {
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  function avatar(): HTMLElement {
+    return el().querySelector('.avatar') as HTMLElement;
+  }
+
+  it('renders uppercase initials and the full name', () => {
+    fixture.componentRef.setInput('referee', referee);
+    fixture.detectChanges();
+
+    expect(avatar().textContent?.trim()).toBe('SM');
+    expect(el().querySelector('.ref-avatar__name')?.textContent).toContain('Szymon Marciniak');
+  });
+
+  it('renders empty without a referee', () => {
+    fixture.detectChanges();
+
+    expect(avatar().textContent?.trim()).toBe('');
+    expect(el().querySelector('.ref-avatar__name')?.textContent?.trim()).toBe('');
+  });
+
+  it('hides the email in the default sm size', () => {
+    fixture.componentRef.setInput('referee', referee);
+    fixture.detectChanges();
+
+    expect(avatar().classList).not.toContain('avatar--lg');
+    expect(el().querySelector('.ref-avatar__email')).toBeNull();
+  });
+
+  it('shows the email and the large avatar in the lg size', () => {
+    fixture.componentRef.setInput('referee', referee);
+    fixture.componentRef.setInput('size', 'lg');
+    fixture.detectChanges();
+
+    expect(avatar().classList).toContain('avatar--lg');
+    expect(el().querySelector('.ref-avatar__email')?.textContent).toContain('szymon.marciniak@example.com');
+  });
+
+  it('skips the email line in lg when the referee has none', () => {
+    fixture.componentRef.setInput('referee', {...referee, email: ''});
+    fixture.componentRef.setInput('size', 'lg');
+    fixture.detectChanges();
+
+    expect(el().querySelector('.ref-avatar__email')).toBeNull();
+  });
+
+  it('copes with a partial name', () => {
+    fixture.componentRef.setInput('referee', {...referee, lastName: ''});
+    fixture.detectChanges();
+
+    expect(avatar().textContent?.trim()).toBe('S');
+    expect(el().querySelector('.ref-avatar__name')?.textContent?.trim()).toBe('Szymon');
+  });
+});

--- a/src/main/webapp/src/app/component/common/team-pill/team-pill.component.spec.ts
+++ b/src/main/webapp/src/app/component/common/team-pill/team-pill.component.spec.ts
@@ -1,0 +1,59 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {TeamPillComponent} from './team-pill.component';
+import {Team} from '../../../model/team';
+
+describe('TeamPillComponent', () => {
+  const team: Team = {id: 1, name: 'Legia Warszawa', city: 'Warszawa', points: 30, short: 'LEG'};
+
+  let fixture: ComponentFixture<TeamPillComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({imports: [TeamPillComponent]}).compileComponents();
+    fixture = TestBed.createComponent(TeamPillComponent);
+  });
+
+  function el(): HTMLElement {
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  function shortEl(): HTMLElement {
+    return el().querySelector('.team-pill__short') as HTMLElement;
+  }
+
+  it('renders the backend short code and the full team name', () => {
+    fixture.componentRef.setInput('team', team);
+    fixture.detectChanges();
+
+    expect(shortEl().textContent?.trim()).toBe('LEG');
+    expect(el().querySelector('.team-pill__name')?.textContent).toContain('Legia Warszawa');
+  });
+
+  it('derives an uppercase 3-letter code from the name when short is absent', () => {
+    fixture.componentRef.setInput('team', {...team, short: undefined});
+    fixture.detectChanges();
+
+    expect(shortEl().textContent?.trim()).toBe('LEG');
+  });
+
+  it('renders empty without a team', () => {
+    fixture.detectChanges();
+
+    expect(shortEl().textContent?.trim()).toBe('');
+    expect(el().querySelector('.team-pill__name')?.textContent?.trim()).toBe('');
+  });
+
+  it('marks the home side with the dark variant by default', () => {
+    fixture.componentRef.setInput('team', team);
+    fixture.detectChanges();
+
+    expect(shortEl().classList).toContain('team-pill__short--home');
+  });
+
+  it('drops the dark variant for the away side', () => {
+    fixture.componentRef.setInput('team', team);
+    fixture.componentRef.setInput('side', 'away');
+    fixture.detectChanges();
+
+    expect(shortEl().classList).not.toContain('team-pill__short--home');
+  });
+});

--- a/src/main/webapp/src/app/component/common/team-pill/team-pill.component.spec.ts
+++ b/src/main/webapp/src/app/component/common/team-pill/team-pill.component.spec.ts
@@ -3,7 +3,9 @@ import {TeamPillComponent} from './team-pill.component';
 import {Team} from '../../../model/team';
 
 describe('TeamPillComponent', () => {
-  const team: Team = {id: 1, name: 'Legia Warszawa', city: 'Warszawa', points: 30, short: 'LEG'};
+  // short deliberately differs from the name-derived prefix ("LEG") so the tests can
+  // tell the backend code apart from the fallback.
+  const team: Team = {id: 1, name: 'Legia Warszawa', city: 'Warszawa', points: 30, short: 'LGW'};
 
   let fixture: ComponentFixture<TeamPillComponent>;
 
@@ -24,7 +26,7 @@ describe('TeamPillComponent', () => {
     fixture.componentRef.setInput('team', team);
     fixture.detectChanges();
 
-    expect(shortEl().textContent?.trim()).toBe('LEG');
+    expect(shortEl().textContent?.trim()).toBe('LGW');
     expect(el().querySelector('.team-pill__name')?.textContent).toContain('Legia Warszawa');
   });
 

--- a/src/main/webapp/src/app/service/toast.service.spec.ts
+++ b/src/main/webapp/src/app/service/toast.service.spec.ts
@@ -1,0 +1,55 @@
+import {TestBed, fakeAsync, tick} from '@angular/core/testing';
+import {ToastService} from './toast.service';
+
+describe('ToastService', () => {
+  const HIDE_AFTER_MS = 4500;
+
+  let service: ToastService;
+
+  beforeEach(() => {
+    service = TestBed.inject(ToastService);
+  });
+
+  it('starts with no toast', () => {
+    expect(service.toast()).toBeNull();
+  });
+
+  it('shows a toast with the default info kind', fakeAsync(() => {
+    service.show('Import finished');
+
+    expect(service.toast()).toEqual({message: 'Import finished', kind: 'info'});
+    tick(HIDE_AFTER_MS);
+  }));
+
+  it('shows an error toast when asked', fakeAsync(() => {
+    service.show('Request failed (HTTP 500)', 'error');
+
+    expect(service.toast()).toEqual({message: 'Request failed (HTTP 500)', kind: 'error'});
+    tick(HIDE_AFTER_MS);
+  }));
+
+  it('auto-hides after the timeout, not before', fakeAsync(() => {
+    service.show('Import finished');
+
+    tick(HIDE_AFTER_MS - 1);
+    expect(service.toast()).not.toBeNull();
+
+    tick(1);
+    expect(service.toast()).toBeNull();
+  }));
+
+  it('replaces the current toast and restarts the hide timer', fakeAsync(() => {
+    service.show('First');
+    tick(HIDE_AFTER_MS - 1000);
+
+    service.show('Second', 'error');
+    expect(service.toast()).toEqual({message: 'Second', kind: 'error'});
+
+    // The first toast's timer would have fired here; the restarted one must not.
+    tick(HIDE_AFTER_MS - 1);
+    expect(service.toast()).toEqual({message: 'Second', kind: 'error'});
+
+    tick(1);
+    expect(service.toast()).toBeNull();
+  }));
+});

--- a/src/main/webapp/src/app/service/ui-settings.service.spec.ts
+++ b/src/main/webapp/src/app/service/ui-settings.service.spec.ts
@@ -1,0 +1,82 @@
+import {TestBed} from '@angular/core/testing';
+import {UiSettingsService} from './ui-settings.service';
+
+describe('UiSettingsService', () => {
+  function reset(): void {
+    localStorage.removeItem('theme');
+    localStorage.removeItem('admin.visible');
+    localStorage.removeItem('staffer.explainer');
+    document.documentElement.removeAttribute('data-theme');
+  }
+
+  // afterEach too: the toggles write localStorage and stamp <html>, and that state
+  // must not leak into whatever suite runs next.
+  beforeEach(reset);
+  afterEach(reset);
+
+  // The constructor reads localStorage, so each test injects the service itself
+  // after arranging the persisted state.
+  function inject(): UiSettingsService {
+    return TestBed.inject(UiSettingsService);
+  }
+
+  it('defaults everything off with a clean localStorage', () => {
+    const service = inject();
+
+    expect(service.dark()).toBeFalse();
+    expect(service.adminVisible()).toBeFalse();
+    expect(service.explainerVisible()).toBeFalse();
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('restores persisted settings on startup', () => {
+    localStorage.setItem('theme', 'dark');
+    localStorage.setItem('admin.visible', 'true');
+    localStorage.setItem('staffer.explainer', 'true');
+
+    const service = inject();
+
+    expect(service.dark()).toBeTrue();
+    expect(service.adminVisible()).toBeTrue();
+    expect(service.explainerVisible()).toBeTrue();
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('toggleDark flips the signal, persists the theme and restamps <html>', () => {
+    const service = inject();
+
+    service.toggleDark();
+    expect(service.dark()).toBeTrue();
+    expect(localStorage.getItem('theme')).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+
+    service.toggleDark();
+    expect(service.dark()).toBeFalse();
+    expect(localStorage.getItem('theme')).toBe('light');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('toggleAdmin flips the signal and persists it', () => {
+    const service = inject();
+
+    service.toggleAdmin();
+    expect(service.adminVisible()).toBeTrue();
+    expect(localStorage.getItem('admin.visible')).toBe('true');
+
+    service.toggleAdmin();
+    expect(service.adminVisible()).toBeFalse();
+    expect(localStorage.getItem('admin.visible')).toBe('false');
+  });
+
+  it('toggleExplainer flips the signal and persists it', () => {
+    const service = inject();
+
+    service.toggleExplainer();
+    expect(service.explainerVisible()).toBeTrue();
+    expect(localStorage.getItem('staffer.explainer')).toBe('true');
+
+    service.toggleExplainer();
+    expect(service.explainerVisible()).toBeFalse();
+    expect(localStorage.getItem('staffer.explainer')).toBe('false');
+  });
+});


### PR DESCRIPTION
## Ticket

[RS-95](https://referee-staffer.youtrack.cloud/issue/RS-95) — Testy frontendu: ToastService, UiSettingsService i atomy z logiką (team-pill, ref-avatar)

This closes the remaining frontend unit-test gap left after RS-80 (HTTP services), RS-81 (hot spots, forms, overlays, lists) and RS-89 (remaining screens): the two non-HTTP services and the two atoms that contain real logic had neither a spec nor a ticket covering them.

## Plan

1. **`ToastService`** — spec with `fakeAsync` + `tick` (no real timers): default kind `info`, explicit `error` kind, auto-hide exactly at `HIDE_AFTER_MS`, and the replacement behaviour — a second `show()` overwrites the current toast **and restarts** the hide timer.
2. **`UiSettingsService`** — the constructor reads localStorage, so each test arranges the persisted state first and injects the service inside the test body; cover the clean-slate defaults, restore-on-startup for all three keys (`theme`, `admin.visible`, `staffer.explainer`), each toggle's signal flip + localStorage write, and the `data-theme` stamp on `<html>`. localStorage and the `data-theme` attribute are reset around every test.
3. **`TeamPillComponent`** — backend `short` code rendering, the 3-letter uppercase fallback derived from `name`, the empty no-team state, and the home/away colour variants (`team-pill__short--home`).
4. **`RefAvatarComponent`** — `initials()`/`fullName()` rendering, `sm` vs `lg` email visibility (`avatar--lg` class), missing email in `lg`, and partial-name edge cases.

The optional low-priority smoke tests for the purely presentational atoms (`icon`, `chip`, `panel`, `kpi`, `meter`, `seg`, toast component) are deliberately left out, as the ticket marks them optional.

## Changes

Four new spec files, no production code touched:

- `src/app/service/toast.service.spec.ts` — 5 tests
- `src/app/service/ui-settings.service.spec.ts` — 5 tests; a shared `reset()` runs in both `beforeEach` **and** `afterEach` so the localStorage keys and the `data-theme` attribute the toggles write cannot leak into whatever suite runs next
- `src/app/component/common/team-pill/team-pill.component.spec.ts` — 5 tests
- `src/app/component/common/ref-avatar/ref-avatar.component.spec.ts` — 6 tests

Conventions follow RS-81/RS-89: standalone-component TestBed setup, `fixture.componentRef.setInput` for signal inputs, assertions against rendered DOM rather than component internals where a template exists.

## Testing

- `npm run lint` — clean.
- `npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox --no-progress` — **269/269 SUCCESS** (21 new tests on top of the previous 248), same invocation as `frontend.yml`.
- Environment note: the container ships Node v22.22.2, one patch below Angular CLI 22's minimum (≥22.22.3), so lint/tests were run locally with Node 24.15.0 — the exact version pinned in `pom.xml` and used by CI.

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpttWxouks7uBBfJ2qaDRu)_